### PR TITLE
Set PKG_CONFIG_PATH, shared libbpf can stay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && \
         
 ARG MAKEFLAGS
 
+ENV PKG_CONFIG_PATH=/usr/lib64/pkgconfig
+
 # linux ver should match target machine's kernel
 WORKDIR /libbpf
 ARG LIBBPF_VER=v0.3
@@ -34,9 +36,6 @@ COPY patches/dpdk/* deps/
 COPY patches/bess patches
 RUN cat patches/* | patch -p1 && \
     ./build.py dpdk
-
-# Hack to get static version linked
-RUN rm -f /usr/lib64/libbpf.so*
 
 # Plugins
 RUN mkdir -p plugins


### PR DESCRIPTION
By setting PKG_CONFIG_PATH BESS makefile is able to get the static
version of libbpf without having to delete the shared version.

Even though libbpf allows compiling only static version, DPDK is
configured to always compile static and shared versions. The shared
version of AF_XDP PMD needs the shared version of libbpf and shared
version of it's dependencies to correctly compile and link.

Signed-off-by: Saikrishna Edupuganti saikrishna.edupuganti@intel.com