### PR TITLE
Increasing Packet burst size 

### DIFF
--- a/patches/bess/0019-Increased_packet_burst_size.patch
+++ b/patches/bess/0019-Increased_packet_burst_size.patch
@@ -1,0 +1,25 @@
+From 4718ef2cdd462d0f9b0d9b4e70740a3213f3589f Mon Sep 17 00:00:00 2001
+From: Ams <amarsri28@gmail.com>
+Date: Wed, 16 Feb 2022 23:41:07 -0800
+Subject: [PATCH] increasing packet size
+
+---
+ core/pktbatch.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/core/pktbatch.h b/core/pktbatch.h
+index a90c4ff1..c3b2a1dd 100644
+--- a/core/pktbatch.h
++++ b/core/pktbatch.h
+@@ -67,7 +67,7 @@ class PacketBatch {
+     bess::utils::CopyInlined(pkts_, src->pkts_, cnt_ * sizeof(Packet *));
+   }
+ 
+-  static const size_t kMaxBurst = 32;
++  static const size_t kMaxBurst = 64;
+ 
+  private:
+   int cnt_;
+-- 
+2.25.1
+


### PR DESCRIPTION
increased burst size was supported already in #329.
we have increased packet burst size to 64 as team has reported 20% approx. performance improvement with 64 as compare to 32.