### PR TITLE
Use zero for unset meter bands in UP4

### DIFF
--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -803,8 +803,8 @@ func getMeterConfigurationFromQER(mbr uint64, gbr uint64) *p4.MeterConfig {
 	logger.Debug("Converting GBR/MBR to P4 Meter configuration")
 
 	// FIXME: calculate from rate once P4-UPF supports GBRs
-	cbs := 1
-	cir := 1
+	cbs := 0
+	cir := 0
 
 	pbs := calcBurstSizeFromRate(mbr, uint64(defaultBurstDurationMs))
 


### PR DESCRIPTION
We now allow using zero as bands for meters in case the band is unset.
See:
- https://github.com/stratum/stratum/pull/930
- https://gerrit.onosproject.org/c/onos/+/25349 
- https://github.com/stratum/fabric-tna/pull/500
- https://github.com/omec-project/up4/pull/249