### PR TITLE
Add GHA based `REUSE` CI check

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -6,9 +6,9 @@ name: REUSE
 
 on:
   push:
-    branches: [master, main]
+    branches:
+      - master
   pull_request:
-    branches: [master, main]
 
 jobs:
   license-check:
@@ -16,4 +16,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: reuse lint
-        uses: fsfe/reuse-action@v1
+        run: make check-reuse

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,19 @@
+# Copyright 2020-present Open Networking Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: REUSE
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  license-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: reuse lint
+        uses: fsfe/reuse-action@v1


### PR DESCRIPTION
We're moving away from jenkins jobs and towards GitHub Actions (GHA). This PR ports the `REUSE` check over and replaces the `omec_upf-epc_reuse` job. 

Taken from: https://github.com/stratum/fabric-tna/blob/main/.github/workflows/reuse.yml