### PR TITLE
Fix clear tables with id 0

### DIFF
--- a/pfcpiface/p4rtc.go
+++ b/pfcpiface/p4rtc.go
@@ -311,7 +311,9 @@ func (c *P4rtClient) ClearTable(tableID uint32) error {
 }
 
 func (c *P4rtClient) ClearTables(tableIDs []uint32) error {
-	log.Traceln("Clearing P4 tables")
+	log.WithFields(log.Fields{
+		"table IDs": tableIDs,
+	}).Traceln("Clearing P4 tables")
 
 	updates := []*p4.Update{}
 

--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -378,7 +378,7 @@ func (up4 *UP4) setUpfInfo(u *upf, conf *Conf) {
 
 func (up4 *UP4) clearAllTables() error {
 	tables := []string{TableUplinkSessions, TableDownlinkSessions, TableUplinkTerminations, TableDownlinkTerminations, TableTunnelPeers, TableApplications}
-	tableIDs := make([]uint32, len(tables))
+	tableIDs := make([]uint32, 0, len(tables))
 
 	for _, table := range tables {
 		tableID, err := up4.p4RtTranslator.getTableIDByName(table)


### PR DESCRIPTION
pfcp-agent tried to clear tables with id=0, because the slice was initialized with zeros. 