### PR TITLE
Force TTY mode for integration test logs

### DIFF
--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -147,7 +147,7 @@ func init() {
 	logrus.SetReportCaller(true)
 	logrus.SetFormatter(&logrus.TextFormatter{
 		FullTimestamp: true,
-		ForceColors: true,
+		ForceColors:   true,
 	})
 }
 

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -144,6 +144,11 @@ type testCase struct {
 
 func init() {
 	logrus.SetLevel(logrus.TraceLevel)
+	logrus.SetReportCaller(true)
+	logrus.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp: true,
+		ForceColors: true,
+	})
 }
 
 func TimeBasedElectionId() p4_v1.Uint128 {


### PR DESCRIPTION
This will force printing the timestamp, calling function and colors on local runs. 
Since test output is not collected by any monitoring system, we can use a more human readable format.

This only affects local runs, GHA already attach a TTY.