### PR TITLE
Fix flow description parsing for uplink

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,9 +24,9 @@ jobs:
         run: |
           make pb
 
-      - name: Build the BESS-UPF Docker image
-        run: |
-          DOCKER_TARGETS=bess make docker-build
+#      - name: Build the BESS-UPF Docker image
+#        run: |
+#          DOCKER_TARGETS=bess make docker-build
 
       - name: Build the PFCP Agent Docker image
         run: |
@@ -66,9 +66,9 @@ jobs:
             core.setFailed('Please run make p4-constants and commit changes')
 
       # Build again and commit
-      - name: Build the BESS-UPF Docker image (after format)
-        run: |
-          DOCKER_TARGETS=bess make docker-build
+#      - name: Build the BESS-UPF Docker image (after format)
+#        run: |
+#          DOCKER_TARGETS=bess make docker-build
 
       - name: Build the PFCP Agent Docker image (after format)
         run: |
@@ -95,4 +95,4 @@ jobs:
       - name: Push Docker image
         if: steps.docker-login.conclusion == 'success'
         run: |
-          make docker-push
+          DOCKER_TARGETS=pfcpiface make docker-push

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,9 +24,9 @@ jobs:
         run: |
           make pb
 
-#      - name: Build the BESS-UPF Docker image
-#        run: |
-#          DOCKER_TARGETS=bess make docker-build
+      - name: Build the BESS-UPF Docker image
+        run: |
+          DOCKER_TARGETS=bess make docker-build
 
       - name: Build the PFCP Agent Docker image
         run: |
@@ -66,9 +66,9 @@ jobs:
             core.setFailed('Please run make p4-constants and commit changes')
 
       # Build again and commit
-#      - name: Build the BESS-UPF Docker image (after format)
-#        run: |
-#          DOCKER_TARGETS=bess make docker-build
+      - name: Build the BESS-UPF Docker image (after format)
+        run: |
+          DOCKER_TARGETS=bess make docker-build
 
       - name: Build the PFCP Agent Docker image (after format)
         run: |
@@ -95,4 +95,4 @@ jobs:
       - name: Push Docker image
         if: steps.docker-login.conclusion == 'success'
         run: |
-          DOCKER_TARGETS=pfcpiface make docker-push
+          make docker-push

--- a/pfcpiface/parse_sdf.go
+++ b/pfcpiface/parse_sdf.go
@@ -128,7 +128,9 @@ func parseFlowDesc(flowDesc, ueIP string) (*ipFilterRule, error) {
 		case "any":
 			fields[i] = "0.0.0.0/0"
 		case "assigned":
-			if ueIP != "" && ueIP != "<nil>" {
+			if ueIP == "0.0.0.0" {
+				fields[i] = "0.0.0.0/0"
+			} else if ueIP != "" && ueIP != "<nil>" {
 				fields[i] = ueIP
 			} else {
 				fields[i] = "0.0.0.0/0"

--- a/pfcpiface/parse_sdf.go
+++ b/pfcpiface/parse_sdf.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	reservedProto = uint8(0xff)
+	reservedProto         = uint8(0xff)
+	Ipv4WildcardNetString = "0.0.0.0/0"
 )
 
 var errBadFilterDesc = errors.New("unsupported Filter Description format")
@@ -126,14 +127,14 @@ func parseFlowDesc(flowDesc, ueIP string) (*ipFilterRule, error) {
 	xform := func(i int) {
 		switch fields[i] {
 		case "any":
-			fields[i] = "0.0.0.0/0"
+			fields[i] = Ipv4WildcardNetString
 		case "assigned":
 			if ueIP == "0.0.0.0" {
-				fields[i] = "0.0.0.0/0"
+				fields[i] = Ipv4WildcardNetString
 			} else if ueIP != "" && ueIP != "<nil>" {
 				fields[i] = ueIP
 			} else {
-				fields[i] = "0.0.0.0/0"
+				fields[i] = Ipv4WildcardNetString
 			}
 		}
 	}


### PR DESCRIPTION
This PR solves an issue with the parsing of flow descriptions for application filtering. When handling uplink PDRs with UPF-based IP address assignment, we produce an invalid `0.0.0.0/32` match on the UE IPv4 address  (instead of `0.0.0.0/0`).

Sample pfcp-agent log (note `srcIP=0.0.0.0/ffffffff`):
```
time="2022-03-08T12:09:03Z" level=debug msg="Parsing flow description" func=github.com/omec-project/upf-epc/pfcpiface.parseFlowDesc file="/pfcpiface/pfcpiface/parse_sdf.go:103"
	flow-description="permit out udp from 172.16.1.67/32 to assigned 6131-6131" ue-address=0.0.0.0

time="2022-03-08T12:09:03Z" level=debug msg="Flow description parsed successfully" func=github.com/omec-project/upf-epc/pfcpiface.parseFlowDesc file="/pfcpiface/pfcpiface/parse_sdf.go:183"
	flow-description="permit out udp from 172.16.1.67/32 to assigned 6131-6131"
	ip-filter="FlowDescription{action=permit, direction=out, proto=17, srcIP=172.16.1.67/32, srcPort={0-65535}, dstIP=0.0.0.0/32, dstPort={6131-6131}}" ue-address=0.0.0.0

time="2022-03-08T12:09:03Z" level=trace msg="PDR(id=57, F-SEID=16477122575176287530, srcIface=1, tunnelIPv4Dst=10.96.5.2/ffffffff, tunnelTEID=4039180284/ffffffff, ueAddress=0.0.0.0,
	applicationFilter=ApplicationFilter(srcIP=0.0.0.0/ffffffff, dstIP=172.16.1.67/ffffffff, proto=17/ff, srcPort={0-65535}, dstPort={6131-6131}),
	precedence=3, F-SEID IP=171071076, counterID=0, farID=57, qerIDs=[536870984 805306439], needDecap=1, allocIPFlag=false)" func="github.com/omec-project/upf-epc/pfcpiface.(*bess).sendMsgToUPF" file="/pfcpiface/pfcpiface/bess.go:146"
```