### PR TITLE
Use smaller port range for application filtering test

### DIFF
--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -96,7 +96,7 @@ func TestSingleUEAttachAndDetach(t *testing.T) {
 				nbAddress:    nodeBAddress,
 				ueAddress:    ueAddress,
 				upfN3Address: upfN3Address,
-				sdfFilter:    "permit out udp from 192.168.1.1/32 to assigned 80-400",
+				sdfFilter:    "permit out udp from 192.168.1.1/32 to assigned 80-100",
 				ulTEID:       15,
 				dlTEID:       16,
 				QFI:          0x9,
@@ -107,7 +107,7 @@ func TestSingleUEAttachAndDetach(t *testing.T) {
 					appIP:        net.ParseIP("192.168.1.1"),
 					appPrefixLen: 32,
 					appPort: portRange{
-						80, 400,
+						80, 100,
 					},
 				},
 				// FIXME: there is a dependency on previous test because pfcpiface doesn't clear application IDs properly
@@ -115,7 +115,7 @@ func TestSingleUEAttachAndDetach(t *testing.T) {
 				appID:        2,
 				tunnelPeerID: 2,
 			},
-			desc: "APPLICATION FILTERING permit out udp from 192.168.1.1/32 to assigned 80-80",
+			desc: "APPLICATION FILTERING permit out udp from 192.168.1.1/32 to assigned 80-100",
 		},
 		{
 			input: &pfcpSessionData{


### PR DESCRIPTION
BESS integration tests fail for wider port ranges. 