### PR TITLE
Revert sleep before initializing interfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/libp2p/go-reuseport v0.1.0
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
-	github.com/omec-project/pfcpsim v0.0.0-20220309084214-9414eb21802a
+	github.com/omec-project/pfcpsim v0.0.0-20220314155633-b303ec1aaad7
 	github.com/p4lang/p4runtime v1.3.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/libp2p/go-reuseport v0.1.0
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
-	github.com/omec-project/pfcpsim v0.0.0-20220314155633-b303ec1aaad7
+	github.com/omec-project/pfcpsim v0.0.0-20220317111127-6be4ce2180b6
 	github.com/p4lang/p4runtime v1.3.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -219,7 +219,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
-github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=
@@ -475,12 +474,10 @@ github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
-github.com/omec-project/pfcpsim v0.0.0-20220309065921-4b91bcc14895 h1:TG4qrTzb1zWfu1utBuaaLgcqSL7foRLKY1VcX/J83Pc=
-github.com/omec-project/pfcpsim v0.0.0-20220309065921-4b91bcc14895/go.mod h1:VpozJhKRcQ5QRW1sl7RLwwqVi+Od7y+tId8419o6xz4=
-github.com/omec-project/pfcpsim v0.0.0-20220309084214-9414eb21802a h1:5WAZa30IUgeCmlpkTZDjIRw+n/AeYx0NB88PppsxUE0=
-github.com/omec-project/pfcpsim v0.0.0-20220309084214-9414eb21802a/go.mod h1:VpozJhKRcQ5QRW1sl7RLwwqVi+Od7y+tId8419o6xz4=
 github.com/omec-project/pfcpsim v0.0.0-20220314155633-b303ec1aaad7 h1:nmicnDsqshaoVaxPbp1G/r6xXdSl8+Sq4gvSWEjrTe4=
 github.com/omec-project/pfcpsim v0.0.0-20220314155633-b303ec1aaad7/go.mod h1:VpozJhKRcQ5QRW1sl7RLwwqVi+Od7y+tId8419o6xz4=
+github.com/omec-project/pfcpsim v0.0.0-20220317111127-6be4ce2180b6 h1:1AGmc83cPEdr+AfwVuEpsxaMbq5eKJLHZ8cVDkNINcQ=
+github.com/omec-project/pfcpsim v0.0.0-20220317111127-6be4ce2180b6/go.mod h1:VpozJhKRcQ5QRW1sl7RLwwqVi+Od7y+tId8419o6xz4=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/go.sum
+++ b/go.sum
@@ -479,6 +479,8 @@ github.com/omec-project/pfcpsim v0.0.0-20220309065921-4b91bcc14895 h1:TG4qrTzb1z
 github.com/omec-project/pfcpsim v0.0.0-20220309065921-4b91bcc14895/go.mod h1:VpozJhKRcQ5QRW1sl7RLwwqVi+Od7y+tId8419o6xz4=
 github.com/omec-project/pfcpsim v0.0.0-20220309084214-9414eb21802a h1:5WAZa30IUgeCmlpkTZDjIRw+n/AeYx0NB88PppsxUE0=
 github.com/omec-project/pfcpsim v0.0.0-20220309084214-9414eb21802a/go.mod h1:VpozJhKRcQ5QRW1sl7RLwwqVi+Od7y+tId8419o6xz4=
+github.com/omec-project/pfcpsim v0.0.0-20220314155633-b303ec1aaad7 h1:nmicnDsqshaoVaxPbp1G/r6xXdSl8+Sq4gvSWEjrTe4=
+github.com/omec-project/pfcpsim v0.0.0-20220314155633-b303ec1aaad7/go.mod h1:VpozJhKRcQ5QRW1sl7RLwwqVi+Od7y+tId8419o6xz4=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -486,6 +486,11 @@ func (up4 *UP4) initialize() error {
 		return err
 	}
 
+	// Give UP4 a while to clear all tables, before initializing the interfaces table.
+	// FIXME: this is an ugly, temporary workaround.
+	//  Should be removed once we serialize Writes on UP4 side.
+	time.Sleep(1 * time.Second)
+
 	up4.initAllCounters()
 	up4.initMetersPools()
 


### PR DESCRIPTION
PR #547 unintentionally removed the workaround in UP4. This PR adds the sleep before interfaces' initialization back. 