### PR TITLE
Rename `UPF` in FOSSA and dep5 configs

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -10,10 +10,10 @@ version: 2
 cli:
   server: https://app.fossa.com
   fetcher: custom
-  project: upf-epc
+  project: upf
 analyze:
   modules:
-  - name: upf-epc
+  - name: upf
     type: raw
-    target: ../upf-epc
-    path: ../upf-epc
+    target: ../upf
+    path: ../upf

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,7 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: upf-epc
+Upstream-Name: upf
 Upstream-Contact: OMEC Developers <omec-dev@opennetworking.org>
-Source: https://github.com/omec-project/upf-epc
+Source: https://github.com/omec-project/upf
 
 Files: pfcpiface/**/*.pb.go
 Copyright: 2016-2017, Nefeli Networks, Inc.


### PR DESCRIPTION
This change updates the upf project name for fossa and dep5 related config files.

Subset of #530 