### PR TITLE
Rename GHCR Docker repository name to `omec-project/upf`

### DIFF
--- a/.github/workflows/delete-untagged.yml
+++ b/.github/workflows/delete-untagged.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           # NOTE: at now only orgs is supported
           owner: omec-project
-          name: upf-epc/${{ matrix.package }}
+          name: upf/${{ matrix.package }}
           # NOTE: using Personal Access Token
           token: ${{ secrets.CR_PAT }}
           untagged-keep-latest: 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     env:
       DOCKER_REGISTRY: "ghcr.io/omec-project/"
-      DOCKER_REPOSITORY: "upf-epc/"
+      DOCKER_REPOSITORY: "upf/"
     runs-on: ubuntu-latest
     steps:
     # Checkout and build

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     env:
-      REPO: "ghcr.io/omec-project/upf-epc/bess_build"
+      REPO: "ghcr.io/omec-project/upf/bess_build"
       TAG: "latest"
       BESS_DPDK_BRANCH: "dpdk-2011-focal"
       DOCKER_PULL: ""

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     env:
       DOCKER_REGISTRY: "ghcr.io/omec-project/"
-      DOCKER_REPOSITORY: "upf-epc/"
+      DOCKER_REPOSITORY: "upf/"
       VERSION: "PR-${{ github.event.pull_request.number }}"
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Multi-stage Dockerfile
 
 # Stage bess-deps: fetch BESS dependencies
-FROM ghcr.io/omec-project/upf-epc/bess_build AS bess-deps
+FROM ghcr.io/omec-project/upf/bess_build AS bess-deps
 # BESS pre-reqs
 WORKDIR /bess
 ARG BESS_COMMIT=dpdk-2011-focal


### PR DESCRIPTION
This change updates the Docker repository name used on GHCR from `ghcr.io/omec-project/upf-epc/<project>` to `ghcr.io/omec-project/upf/<project>` in the Dockerfile and GHAs.