### PR TITLE
Fix counter initialization in UP4 plugin

### DIFF
--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -202,12 +202,12 @@ func (up4 *UP4) PortStats(uc *upfCollector, ch chan<- prometheus.Metric) {
 }
 
 func (up4 *UP4) initCounter(counterID uint8, name string, counterSize uint64) {
-	up4.counters[counterID].maxSize = uint64(counterSize)
+	up4.counters[counterID].maxSize = counterSize
 	up4.counters[counterID].counterID = uint64(counterID)
 	up4.counters[counterID].counterIDsPool = set.NewSet()
 
-	for i := uint64(0); i < up4.counters[counterID].maxSize+1; i++ {
-		up4.counters[counterID].counterIDsPool.Add(uint64(i))
+	for i := uint64(0); i < up4.counters[counterID].maxSize; i++ {
+		up4.counters[counterID].counterIDsPool.Add(i)
 	}
 
 	log.WithFields(log.Fields{


### PR DESCRIPTION
Counters start from 0 in P4Runtime, so we should allocate indeces from 0 to maxSize-1.