### PR TITLE
[SDFAB-1100] Remove initialization sleep

### DIFF
--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -571,11 +571,6 @@ func (up4 *UP4) initialize() error {
 		return err
 	}
 
-	// Give UP4 a while to clear all tables, before initializing the interfaces table.
-	// FIXME: this is an ugly, temporary workaround.
-	//  Should be removed once we serialize Writes on UP4 side.
-	time.Sleep(1 * time.Second)
-
 	up4.initAllCounters()
 	up4.initMetersPools()
 


### PR DESCRIPTION
With the support of in-order processing in UP4/ONOS it is no longer needed this workaround