### PR TITLE
Patch BESS GUI to not break on special chars in module names

### DIFF
--- a/patches/bess/0019-GUI-dot-module-name-quote.patch
+++ b/patches/bess/0019-GUI-dot-module-name-quote.patch
@@ -1,0 +1,13 @@
+diff --git a/bessctl/static/pipeline.js b/bessctl/static/pipeline.js
+index f0041745..94c45abe 100644
+--- a/bessctl/static/pipeline.js
++++ b/bessctl/static/pipeline.js
+@@ -134,7 +134,7 @@ function graph_to_dot(modules) {
+         var ogates = module.show_ogates ? gates_to_str(module.ogates, 'ogate') : '';
+ 
+         nodes += `
+-  ${module_name} [shape=plaintext label=
++  "${module_name}" [shape=plaintext label=
+     <<table port="mod" border="1" cellborder="0" cellspacing="0" cellpadding="1">
+       ${igates}<tr>
+         <td width="60">${module_name}</td>


### PR DESCRIPTION
This allow using all kinds of non-alphanumeric characters to be used on module names, without breaking the GUI to cease displaying the pipeline.