### PR TITLE
Clear UP4 state after forwarding config is retrieved and close P4rt stream on channel setup error

### DIFF
--- a/pfcpiface/p4rt_translator.go
+++ b/pfcpiface/p4rt_translator.go
@@ -54,10 +54,10 @@ type tunnelParams struct {
 }
 
 type P4rtTranslator struct {
-	p4Info p4ConfigV1.P4Info
+	p4Info *p4ConfigV1.P4Info
 }
 
-func newP4RtTranslator(p4info p4ConfigV1.P4Info) *P4rtTranslator {
+func newP4RtTranslator(p4info *p4ConfigV1.P4Info) *P4rtTranslator {
 	return &P4rtTranslator{
 		p4Info: p4info,
 	}

--- a/pfcpiface/p4rtc.go
+++ b/pfcpiface/p4rtc.go
@@ -601,6 +601,7 @@ func CreateChannel(host string, deviceID uint64) (*P4rtClient, error) {
 	if err != nil {
 		log.Error("Set Mastership error: ", err)
 		closeStreamOnError()
+
 		return nil, err
 	}
 

--- a/pfcpiface/p4rtc.go
+++ b/pfcpiface/p4rtc.go
@@ -51,7 +51,7 @@ type P4rtClient struct {
 	digests    chan *p4.DigestList
 
 	// exported fields
-	P4Info p4ConfigV1.P4Info
+	P4Info *p4ConfigV1.P4Info
 }
 
 type P4RuntimeError struct {
@@ -446,7 +446,7 @@ func (c *P4rtClient) GetForwardingPipelineConfig() (err error) {
 			"Operation successful, but no P4 config provided.")
 	}
 
-	c.P4Info = *pipeline.Config.P4Info
+	c.P4Info = pipeline.Config.P4Info
 
 	getLog.Info("Got ForwardingPipelineConfig from P4Rt device")
 
@@ -479,15 +479,15 @@ func (c *P4rtClient) SetForwardingPipelineConfig(p4InfoPath, deviceConfigPath st
 		return
 	}
 
-	var p4info p4ConfigV1.P4Info
+	p4Info := &p4ConfigV1.P4Info{}
 
-	err = proto.UnmarshalText(string(p4infoBytes), &p4info)
+	err = proto.UnmarshalText(string(p4infoBytes), p4Info)
 	if err != nil {
 		log.Println("Unmarshal test failed for p4info ", err)
 		return
 	}
 
-	c.P4Info = p4info
+	c.P4Info = p4Info
 
 	deviceConfig, err := LoadDeviceConfig(deviceConfigPath)
 	if err != nil {
@@ -496,7 +496,7 @@ func (c *P4rtClient) SetForwardingPipelineConfig(p4InfoPath, deviceConfigPath st
 	}
 
 	var pipeline p4.ForwardingPipelineConfig
-	pipeline.P4Info = &p4info
+	pipeline.P4Info = p4Info
 	pipeline.P4DeviceConfig = deviceConfig
 
 	err = SetPipelineConfig(c.client, c.deviceID, &c.electionID, &pipeline)

--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -291,11 +291,6 @@ func (up4 *UP4) setupChannel() error {
 
 	up4.p4client = client
 
-	err = up4.p4client.GetForwardingPipelineConfig()
-	if err != nil {
-		return err
-	}
-
 	up4.p4RtTranslator = newP4RtTranslator(up4.p4client.P4Info)
 
 	setupLog.Debug("P4Rt channel created")


### PR DESCRIPTION
Fixes the issue with STC in https://github.com/omec-project/up4/pull/290 if `clear_state_on_restart` is set to `false`. 

Also, fixes SDFAB-1174.