### PR TITLE
Address the issues with lint showing in all of the open PRs

### DIFF
--- a/pfcpiface/metrics/prometheus_test.go
+++ b/pfcpiface/metrics/prometheus_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 )
 
-// TODO: we currently need to reset the DefaultRegisterer between tests, as some leave the
-// 		 the registry in a bad state. Use custom registries to avoid global state.
+// TODO: we currently need to reset the DefaultRegisterer between tests, as some
+// leave the registry in a bad state. Use custom registries to avoid global state.
 var backupGlobalRegistry prometheus.Registerer
 
 func saveReg() {

--- a/pfcpiface/pfcpiface.go
+++ b/pfcpiface/pfcpiface.go
@@ -81,7 +81,10 @@ func (p *PFCPIface) mustInit() {
 		log.Fatalln("setupProm failed", err)
 	}
 
-	p.httpSrv = &http.Server{Addr: p.httpEndpoint, Handler: httpMux}
+	// Note: due to error with golangci-lint ("Error: G112: Potential Slowloris Attack
+	// because ReadHeaderTimeout is not configured in the http.Server (gosec)"),
+	// the ReadHeaderTimeout is set to the same value as in nginx (client_header_timeout)
+	p.httpSrv = &http.Server{Addr: p.httpEndpoint, Handler: httpMux, ReadHeaderTimeout: 60 * time.Second}
 }
 
 func (p *PFCPIface) Run() {

--- a/pfcpiface/telemetry_test.go
+++ b/pfcpiface/telemetry_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 )
 
-// TODO: we currently need to reset the DefaultRegisterer between tests, as some leave the
-// 		 the registry in a bad state. Use custom registries to avoid global state.
+// TODO: we currently need to reset the DefaultRegisterer between tests, as some
+// leave the registry in a bad state. Use custom registries to avoid global state.
 var backupGlobalRegistry prometheus.Registerer
 
 func saveReg() {


### PR DESCRIPTION
Currently, lint (golangci-lint) is failing due to a problem related to gofmt in 2 files and a gosec problem with the pfcpiface.go file. This PR should address these issues