### PR TITLE
Mark GTP (IP) packets with the same DSCP value as the inner IP packet

### DIFF
--- a/core/modules/gtpu_encap.cc
+++ b/core/modules/gtpu_encap.cc
@@ -123,6 +123,10 @@ void GtpuEncap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
     uint16_t pkt_len = p->total_len() - sizeof(Ethernet);
     Ethernet *eth = p->head_data<Ethernet *>();
 
+    /* get Type of Service from IP packet */
+    Ipv4 *iphIn = (Ipv4 *)((unsigned char *)eth + sizeof(Ethernet));
+    uint8_t type_of_service = iphIn->type_of_service;
+
     /* pre-allocate space for encaped header(s) */
     char *new_p = static_cast<char *>(p->prepend(encap_size));
     if (new_p == NULL) {
@@ -173,6 +177,7 @@ void GtpuEncap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
     iph->length = (be16_t)(iplen);
     iph->src = (be32_t)(at_tout_sip);
     iph->dst = (be32_t)(at_tout_dip);
+    iph->type_of_service = type_of_service;
 
     EmitPacket(ctx, p, FORWARD_GATE);
   }


### PR DESCRIPTION
Currently, the IP packet for the GTP tunnel have a default DSCP value of 0. What this patch does is:
- Copy the DSCP value from the incoming IP packet (N6 interface) and set it in the outer IP packet for the GTP tunnel (N3/N9 interface)
- Copy the DSCP value from the inner IP packet of the N3/N9 interface and set it in the outer IP for the outgoing packet of the N9/N3 interface