### PR TITLE
Code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The PFCP Agent implements datapath plugins that translate
 
 The combination of PFCP Agent and UP4 is usually referred to as P4-UPF. While BESS-UPF denotes the combination of PFCP Agent and the BESS datapath.
 
-PFCP Agent internally abstracts different datapaths using a common API, while the different plug-ins can use spcific southbound protocols to communicate with the different datapath instances. Support for new datapaths can be provided by implementing new plugins.
+PFCP Agent internally abstracts different datapaths using a common API, while the different plug-ins can use specific southbound protocols to communicate with the different datapath instances. Support for new datapaths can be provided by implementing new plugins.
 
 ### Feature List
 

--- a/conf/ports.py
+++ b/conf/ports.py
@@ -247,15 +247,15 @@ class Port:
         if self.mode == 'sim':
             rewrite = Rewrite(name="{}_rewrite".format(self.name), templates=type_of_packets)
             update = SequentialUpdate(name="{}_update".format(self.name), **seq_kwargs)
-            udpcsum = L4Checksum()
-            ipcsum = IPChecksum()
+            l4cksum = L4Checksum()
+            ipcksum = IPChecksum()
 
             self.fpi.connect(next_mod=rewrite)
             rewrite.connect(next_mod=update)
-            update.connect(next_mod=udpcsum)
-            udpcsum.connect(next_mod=ipcsum)
+            update.connect(next_mod=l4cksum)
+            l4cksum.connect(next_mod=ipcksum)
 
-            inc = ipcsum
+            inc = ipcksum
 
         # enable telemetrics (if enabled) (how many bytes seen in and out of port)
         if conf_measure:

--- a/conf/up4.bess
+++ b/conf/up4.bess
@@ -247,13 +247,13 @@ if parser.enable_slice_metering:
     _in = sliceMeter
 
 farLookup::ExactMatch(fields=[{'attr_name':'far_id', 'num_bytes':4}, \
-                                     {'attr_name':'fseid', 'num_bytes':8}], \
-                             values=[{'attr_name':'action', 'num_bytes':1}, \
-                                     {'attr_name':'tunnel_out_type', 'num_bytes':1}, \
-                                     {'attr_name':'tunnel_out_src_ip4addr', 'num_bytes':4}, \
-                                     {'attr_name':'tunnel_out_dst_ip4addr', 'num_bytes':4}, \
-                                     {'attr_name':'tunnel_out_teid', 'num_bytes':4}, \
-                                     {'attr_name':'tunnel_out_udp_port', 'num_bytes':2}],\
+                              {'attr_name':'fseid', 'num_bytes':8}], \
+                      values=[{'attr_name':'action', 'num_bytes':1}, \
+                              {'attr_name':'tunnel_out_type', 'num_bytes':1}, \
+                              {'attr_name':'tunnel_out_src_ip4addr', 'num_bytes':4}, \
+                              {'attr_name':'tunnel_out_dst_ip4addr', 'num_bytes':4}, \
+                              {'attr_name':'tunnel_out_teid', 'num_bytes':4}, \
+                              {'attr_name':'tunnel_out_udp_port', 'num_bytes':2}],\
                       entries=parser.table_size_far_lookup):noGTPUEncap \
     -> farMerge::Merge() \
     -> _in

--- a/conf/up4.bess
+++ b/conf/up4.bess
@@ -274,8 +274,8 @@ sessionQERLookup.set_default_gate(gate=qerFailGate)
 # Add logical pipeline when gtpuencap is needed
 farLookup:GTPUEncap \
     -> gtpuEncap::GtpuEncap(add_psc=parser.gtppsc):1 \
-    -> outerUDPCsum::L4Checksum() \
-    -> outerIPCsum::IPChecksum() \
+    -> outerL4Cksum::L4Checksum() \
+    -> outerIPCksum::IPChecksum() \
     -> farMerge
 
 notify = UnixSocketPort(name='notifyCP', path=parser.notify_sockaddr)
@@ -318,10 +318,10 @@ if ports[parser.core_ifname].ext_addrs is not None:
 # 1. Build initial DL pipeline here
 coreFastBPF:UEGate \
     -> coreRxIPCksum::IPChecksum(verify=True, hw=parser.hwcksum) \
-    -> coreRxUDPCksum::L4Checksum(verify=True, hw=parser.hwcksum)
+    -> coreRxL4Cksum::L4Checksum(verify=True, hw=parser.hwcksum)
 
 # Record last module to chain up optional modules
-_in = coreRxUDPCksum
+_in = coreRxL4Cksum
 gate = 0
 
 # Append nat module (if enabled)
@@ -350,7 +350,7 @@ else:
 
 # Drop unknown packets
 coreRxIPCksum:1 -> coreRxIPCksumFail::Sink()
-coreRxUDPCksum:1 -> coreRxUDPCksumFail::Sink()
+coreRxL4Cksum:1 -> coreRxL4CksumFail::Sink()
 
 # Add Core filter rules, i.e.:
 # setting filter to detect ue_filter traffic
@@ -389,10 +389,10 @@ GTPUGate = 0
 # 1. Build initial UL pipeline here
 accessFastBPF:GTPUGate \
     -> accessRxIPCksum::IPChecksum(verify=True, hw=parser.hwcksum) \
-    -> accessRxUDPCksum::L4Checksum(verify=True, hw=parser.hwcksum)
+    -> accessRxL4Cksum::L4Checksum(verify=True, hw=parser.hwcksum)
 
 # Record last module to chain up option modules
-_in = accessRxUDPCksum
+_in = accessRxL4Cksum
 gate = 0
 
 # 2. Build the remaining first half of the UL pipeline before entering the shared pipeline
@@ -416,14 +416,14 @@ else:
 accessFastBPF:GTPUEchoGate \
     -> gtpuEcho::GtpuEcho(s1u_sgw_ip=ip2long(access_ip[0])):1 \
     -> ethSwap::MACSwap() \
-    -> echoOuterUDPCsum::L4Checksum() \
-    -> echoOuterIPCsum::IPChecksum() \
+    -> echoOuterL4Cksum::L4Checksum() \
+    -> echoOuterIPCksum::IPChecksum() \
     -> ports[parser.access_ifname].rtr
 
 # Drop unknown packets
 gtpuEcho:0 -> badGtpuEchoPkt::Sink()
 accessRxIPCksum:1 -> accessRxIPCksumFail::Sink()
-accessRxUDPCksum:1 -> accessRxUDPCksumFail::Sink()
+accessRxL4Cksum:1 -> accessRxL4CksumFail::Sink()
 
 # Add Access filter rules, i.e.:
 # setting filter to detect gtpu traffic

--- a/core/modules/counter.cc
+++ b/core/modules/counter.cc
@@ -48,9 +48,9 @@ CommandResponse Counter::RemoveCounter(const bess::pb::CounterRemoveArg &arg) {
 #ifdef HASHMAP_BASED
   /* check_exist is still here for over-protection */
   if (counters.find(ctr_id) != counters.end()) {
-    std::cerr << this->name() << "[" << ctr_id
-              << "]: " << counters[ctr_id].pkt_count << ", "
-              << counters[ctr_id].byte_count << std::endl;
+    DLOG(WARNING) << this->name() << "[" << ctr_id
+                  << "]: " << counters[ctr_id].pkt_count << ", "
+                  << counters[ctr_id].byte_count;
     counters.erase(ctr_id);
   } else {
     return CommandFailure(EINVAL, "Unable to remove ctr");
@@ -59,7 +59,7 @@ CommandResponse Counter::RemoveCounter(const bess::pb::CounterRemoveArg &arg) {
   if (ctr_id < total_count && counters[ctr_id].pkt_count != 0) {
     DLOG(INFO) << this->name() << "[" << ctr_id
                << "]: " << counters[ctr_id].pkt_count << ", "
-               << counters[ctr_id].byte_count << std::endl;
+               << counters[ctr_id].byte_count;
     counters[ctr_id].pkt_count = counters[ctr_id].byte_count = 0;
   }
   curr_count--;

--- a/core/modules/flow_measure.h
+++ b/core/modules/flow_measure.h
@@ -76,7 +76,7 @@ class FlowMeasure final : public Module {
     TableKey() : fseid(0), pdr(0) {}
     std::string ToString() const {
       std::stringstream ss;
-      ss << "{ fseid: " << fseid << ", pdr: " << pdr + " }";
+      ss << "{ fseid: " << fseid << ", pdr: " << pdr << " }";
       return ss.str();
     }
   };

--- a/core/modules/gtpu_encap.cc
+++ b/core/modules/gtpu_encap.cc
@@ -118,7 +118,7 @@ void GtpuEncap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
                << ", tunnel out sip: " << at_tout_sip
                << ", tunnel out dip: " << at_tout_dip
                << ", tunnel out teid: " << at_tout_teid
-               << ", tunnel out udp port: " << at_tout_uport << std::endl;
+               << ", tunnel out udp port: " << at_tout_uport;
 
     uint16_t pkt_len = p->total_len() - sizeof(Ethernet);
     Ethernet *eth = p->head_data<Ethernet *>();
@@ -128,7 +128,7 @@ void GtpuEncap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
     if (new_p == NULL) {
       /* failed to prepend header space for encaped packet */
       EmitPacket(ctx, p, DEFAULT_GATE);
-      DLOG(INFO) << "prepend() failed!" << std::endl;
+      DLOG(INFO) << "prepend() failed!";
       continue;
     }
 
@@ -188,21 +188,21 @@ CommandResponse GtpuEncap::Init(const bess::pb::GtpuEncapArg &arg) {
 
   using AccessMode = bess::metadata::Attribute::AccessMode;
   pdu_type_attr = AddMetadataAttr("action", sizeof(uint8_t), AccessMode::kRead);
-  DLOG(INFO) << "tout_sip_attr: " << tout_sip_attr << std::endl;
+  DLOG(INFO) << "tout_sip_attr: " << tout_sip_attr;
   tout_sip_attr = AddMetadataAttr("tunnel_out_src_ip4addr", sizeof(uint32_t),
                                   AccessMode::kRead);
-  DLOG(INFO) << "tout_sip_attr: " << tout_sip_attr << std::endl;
+  DLOG(INFO) << "tout_sip_attr: " << tout_sip_attr;
   tout_dip_attr = AddMetadataAttr("tunnel_out_dst_ip4addr", sizeof(uint32_t),
                                   AccessMode::kRead);
-  DLOG(INFO) << "tout_dip_attr: " << tout_dip_attr << std::endl;
+  DLOG(INFO) << "tout_dip_attr: " << tout_dip_attr;
   tout_teid =
       AddMetadataAttr("tunnel_out_teid", sizeof(uint32_t), AccessMode::kRead);
-  DLOG(INFO) << "tout_teid: " << tout_teid << std::endl;
+  DLOG(INFO) << "tout_teid: " << tout_teid;
   tout_uport = AddMetadataAttr("tunnel_out_udp_port", sizeof(uint16_t),
                                AccessMode::kRead);
-  DLOG(INFO) << "tout_uport: " << tout_uport << std::endl;
+  DLOG(INFO) << "tout_uport: " << tout_uport;
   qfi_attr = AddMetadataAttr("qfi", sizeof(uint8_t), AccessMode::kRead);
-  DLOG(INFO) << "qfi_attr: " << qfi_attr << std::endl;
+  DLOG(INFO) << "qfi_attr: " << qfi_attr;
 
   return CommandSuccess();
 }

--- a/core/modules/ip_defrag.cc
+++ b/core/modules/ip_defrag.cc
@@ -61,7 +61,7 @@ bess::Packet *IPDefrag::IPReassemble(Context *ctx, bess::Packet *p) {
         iph = (Ipv4 *)((unsigned char *)eth + sizeof(Ethernet));
       } else {
         DLOG(INFO) << "Failed to linearize rte_mbuf. "
-                   << "Is there enough tail room?" << std::endl;
+                   << "Is there enough tail room?";
         EmitPacket(ctx, p, DEFAULT_GATE);
         return NULL;
       }

--- a/core/modules/ip_frag.cc
+++ b/core/modules/ip_frag.cc
@@ -163,7 +163,7 @@ void IPFrag::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
 CommandResponse IPFrag::GetEthMTU(const bess::pb::EmptyArg &) {
   bess::pb::IPFragArg arg;
   arg.set_mtu(eth_mtu);
-  DLOG(INFO) << "Ethernet MTU Size: " << eth_mtu << std::endl;
+  DLOG(INFO) << "Ethernet MTU Size: " << eth_mtu;
   return CommandSuccess(arg);
 }
 /*----------------------------------------------------------------------------------*/

--- a/core/modules/qos.cc
+++ b/core/modules/qos.cc
@@ -157,7 +157,7 @@ void Qos::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
     }
 
     uint16_t ogate = val[j]->ogate;
-    DLOG(INFO) << "ogate : " << ogate << std::endl;
+    DLOG(INFO) << "ogate : " << ogate;
 
     // meter if ogate is 0
     if (ogate == METER_GATE) {
@@ -166,7 +166,7 @@ void Qos::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
       uint8_t color = rte_meter_trtcm_color_blind_check(&val[j]->m, &val[j]->p,
                                                         time, pkt_len);
 
-      DLOG(INFO) << "color : " << color << std::endl;
+      DLOG(INFO) << "color : " << color;
       // update ogate to color specific gate
       if (color == RTE_COLOR_GREEN) {
         ogate = METER_GREEN_GATE;
@@ -199,7 +199,7 @@ void Qos::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
                    << *(reinterpret_cast<uint64_t *>(buf))
                    << " for attr_id: " << value_attr_id
                    << " of size: " << value_size
-                   << " at value_pos: " << value_pos << std::endl;
+                   << " at value_pos: " << value_pos;
 
         switch (value_size) {
           case 1:
@@ -373,7 +373,7 @@ CommandResponse Qos::CommandAdd(const bess::pb::QosCommandAddArg &arg) {
 
     DLOG(INFO) << "Adding entry"
                << " cir: " << cir << " pir: " << pir << " cbs: " << cbs
-               << " pbs: " << pbs << " ebs: " << ebs << std::endl;
+               << " pbs: " << pbs << " ebs: " << ebs;
 
     struct rte_meter_trtcm_params app_trtcm_params = {
         .cir = cir, .pir = pir, .cbs = cbs, .pbs = pbs};

--- a/core/modules/qos.h
+++ b/core/modules/qos.h
@@ -54,7 +54,11 @@ class Qos final : public Module {
 
   static const Commands cmds;
 
-  Qos() : Module(), default_gate_(), total_key_size_(), fields_() {
+  Qos()
+      : Module(),
+        default_gate_(),
+        total_key_size_(),
+        fields_() {
     max_allowed_workers_ = Worker::kMaxWorkers;
     size_t len = sizeof(mask) / sizeof(uint64_t);
     for (size_t i = 0; i < len; i++)
@@ -76,7 +80,7 @@ class Qos final : public Module {
   CommandResponse AddFieldOne(const bess::pb::Field &field,
                               struct MeteringField *f, uint8_t type);
   gate_idx_t LookupEntry(const MeteringKey &key, gate_idx_t def_gate);
-  void DeInit();
+  void DeInit() override;
   std::string GetDesc() const override;
 
  private:

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -8,7 +8,7 @@ Copyright 2022 Open Networking Foundation
 
 The `upf` repository relies on some external Go dependencies, which are not mature yet (e.g. pfcpsim or p4runtime-go-client).
 It's often needed to extend those dependencies first, before adding a new feature to the PFCP Agent. However, when using Go modules and Dockerized environment,
-it's hard to test WIP changes to local dependencies. Therefore, this repository come up with a way to use Go vendoring, instead of Go modules, for development purposes.
+it's hard to test WIP changes to local dependencies. Therefore, this repository comes up with a way to use Go vendoring, instead of Go modules, for development purposes.
 
 To use a local Go dependency add the `replace` directive to `go.mod`. An example:
 

--- a/patches/bess/0008-Enable-hardware-checksum-offload.patch
+++ b/patches/bess/0008-Enable-hardware-checksum-offload.patch
@@ -25,7 +25,7 @@ index 9b29fc85..1501ea94 100644
    ret = rte_eth_dev_configure(ret_port_id, num_rxq, num_txq, &eth_conf);
    if (ret != 0) {
 +    VLOG(1) << "Failed to configure with hardware checksum offload. "
-+            << "Create PMDPort without hardware offload" << std::endl;
++            << "Create PMDPort without hardware offload";
      return CommandFailure(-ret, "rte_eth_dev_configure() failed");
    }
  

--- a/patches/bess/0009-Adding-value-attributes-to-ExactMatch-WildcardMatch.patch
+++ b/patches/bess/0009-Adding-value-attributes-to-ExactMatch-WildcardMatch.patch
@@ -11,7 +11,7 @@ Subject: [PATCH] Adding value attributes to ExactMatch & WildcardMatch.
  4 files changed, 458 insertions(+), 49 deletions(-)
 
 diff --git a/core/modules/exact_match.cc b/core/modules/exact_match.cc
-index 072a0333..1ca0fd4e 100644
+index 072a0333..751d5f32 100644
 --- a/core/modules/exact_match.cc
 +++ b/core/modules/exact_match.cc
 @@ -50,20 +50,21 @@ const Commands ExactMatch::cmds = {
@@ -202,7 +202,7 @@ index 072a0333..1ca0fd4e 100644
    }
  }
  
-@@ -250,20 +347,35 @@ std::string ExactMatch::GetDesc() const {
+@@ -250,20 +347,34 @@ std::string ExactMatch::GetDesc() const {
  
  void ExactMatch::RuleFieldsFromPb(
      const RepeatedPtrField<bess::pb::FieldData> &fields,
@@ -237,12 +237,11 @@ index 072a0333..1ca0fd4e 100644
 +      }
        for (int j = 0; j < field_size; j++) {
          rule->back().push_back(rule64 & 0xFFULL);
-+        DLOG(INFO) << "Pushed " << std::hex << (rule64 & 0xFFULL) << " to rule."
-+                   << std::endl;
++        DLOG(INFO) << "Pushed " << std::hex << (rule64 & 0xFFULL) << " to rule.";
          rule64 >>= 8;
        }
      }
-@@ -289,7 +401,7 @@ CommandResponse ExactMatch::CommandDelete(
+@@ -289,7 +400,7 @@ CommandResponse ExactMatch::CommandDelete(
    }
  
    ExactMatchRuleFields rule;
@@ -468,7 +467,7 @@ index f7560e97..99cb2654 100644
  
  #endif  // BESS_MODULES_EXACTMATCH_H_
 diff --git a/core/modules/wildcard_match.cc b/core/modules/wildcard_match.cc
-index 1b7bfeb6..ec639a7b 100644
+index 1b7bfeb6..82b954be 100644
 --- a/core/modules/wildcard_match.cc
 +++ b/core/modules/wildcard_match.cc
 @@ -37,6 +37,7 @@
@@ -574,8 +573,8 @@ index 1b7bfeb6..ec639a7b 100644
 +      int value_attr_id = values_[i].attr_id;
 +      uint8_t *data = pkt->head_data<uint8_t *>() + value_off;
 +
-+      DLOG(INFO) << "off: " << (int)value_off << ", sz: " << value_size
-+                 << std::endl;
++      DLOG(INFO) << "off: " << (int)value_off << ", sz: " << value_size;
++
 +      if (value_attr_id < 0) { /* if it is offset-based */
 +        memcpy(data, reinterpret_cast<uint8_t *>(&result.keyv) + value_pos,
 +               value_size);
@@ -589,7 +588,7 @@ index 1b7bfeb6..ec639a7b 100644
 +                   << *(reinterpret_cast<uint64_t *>(buf))
 +                   << " for attr_id: " << value_attr_id
 +                   << " of size: " << value_size
-+                   << " at value_pos: " << value_pos << std::endl;
++                   << " at value_pos: " << value_pos;
 +
 +        switch (value_size) {
 +          case 1:

--- a/patches/bess/0012-Dpdk-concurrent-hash-support-pipeline-improvement.patch
+++ b/patches/bess/0012-Dpdk-concurrent-hash-support-pipeline-improvement.patch
@@ -13,7 +13,7 @@ Subject: [PATCH] Dpdk Hash table support for concurrent pipeline
  6 files changed, 391 insertions(+), 114 deletions(-)
 
 diff --git a/core/modules/exact_match.cc b/core/modules/exact_match.cc
-index b8bb2a6d..fee70a78 100644
+index 751d5f32..144e167e 100644
 --- a/core/modules/exact_match.cc
 +++ b/core/modules/exact_match.cc
 @@ -134,7 +134,7 @@ CommandResponse ExactMatch::Init(const bess::pb::ExactMatchArg &arg) {
@@ -51,7 +51,7 @@ index b8bb2a6d..fee70a78 100644
    }
  }
  
-@@ -422,4 +420,8 @@ CommandResponse ExactMatch::CommandSetDefaultGate(
+@@ -421,4 +419,8 @@ CommandResponse ExactMatch::CommandSetDefaultGate(
    return CommandSuccess();
  }
  
@@ -75,7 +75,7 @@ index 99cb2654..d7e3531e 100644
    CommandResponse GetRuntimeConfig(const bess::pb::EmptyArg &arg);
    CommandResponse SetRuntimeConfig(const bess::pb::ExactMatchConfig &arg);
 diff --git a/core/modules/wildcard_match.cc b/core/modules/wildcard_match.cc
-index ec639a7b..51e67c55 100644
+index 82b954be..2214be8f 100644
 --- a/core/modules/wildcard_match.cc
 +++ b/core/modules/wildcard_match.cc
 @@ -40,13 +40,28 @@ using bess::metadata::Attribute;
@@ -146,7 +146,16 @@ index ec639a7b..51e67c55 100644
      }
    }
  
-@@ -232,20 +243,115 @@ inline gate_idx_t WildcardMatch::LookupEntry(const wm_hkey_t &key,
+@@ -187,7 +198,7 @@ inline gate_idx_t WildcardMatch::LookupEntry(const wm_hkey_t &key,
+       int value_attr_id = values_[i].attr_id;
+       uint8_t *data = pkt->head_data<uint8_t *>() + value_off;
+ 
+-      DLOG(INFO) << "off: " << (int)value_off << ", sz: " << value_size;
++      DLOG(INFO) << "off: " << value_off << ", sz: " << value_size;
+ 
+       if (value_attr_id < 0) { /* if it is offset-based */
+         memcpy(data, reinterpret_cast<uint8_t *>(&result.keyv) + value_pos,
+@@ -232,20 +243,114 @@ inline gate_idx_t WildcardMatch::LookupEntry(const wm_hkey_t &key,
    return result.ogate;
  }
  
@@ -199,8 +208,7 @@ index ec639a7b..51e67c55 100644
 +        int value_attr_id = values_[i].attr_id;
 +        uint8_t *data = pkt->head_data<uint8_t *>() + value_off;
 +
-+        DLOG(INFO) << "off: " << (int)value_off << ", sz: " << value_size
-+                   << std::endl;
++        DLOG(INFO) << "off: " << value_off << ", sz: " << value_size;
 +        if (value_attr_id < 0) { /* if it is offset-based */
 +          memcpy(data,
 +                 reinterpret_cast<uint8_t *>(&result[init]->keyv) + value_pos,
@@ -215,7 +223,7 @@ index ec639a7b..51e67c55 100644
 +                     << *(reinterpret_cast<uint64_t *>(buf))
 +                     << " for attr_id: " << value_attr_id
 +                     << " of size: " << value_size
-+                     << " at value_pos: " << value_pos << std::endl;
++                     << " at value_pos: " << value_pos;
 +
 +          switch (value_size) {
 +            case 1:
@@ -266,7 +274,7 @@ index ec639a7b..51e67c55 100644
    for (const auto &field : fields_) {
      int offset;
      int pos = field.pos;
-@@ -272,9 +378,9 @@ void WildcardMatch::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
+@@ -272,9 +377,9 @@ void WildcardMatch::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
      }
    }
  
@@ -279,7 +287,7 @@ index ec639a7b..51e67c55 100644
    }
  }
  
-@@ -282,7 +388,9 @@ std::string WildcardMatch::GetDesc() const {
+@@ -282,7 +387,9 @@ std::string WildcardMatch::GetDesc() const {
    int num_rules = 0;
  
    for (const auto &tuple : tuples_) {
@@ -290,7 +298,7 @@ index ec639a7b..51e67c55 100644
    }
  
    return bess::utils::Format("%zu fields, %d rules", fields_.size(), num_rules);
-@@ -387,54 +495,60 @@ CommandResponse WildcardMatch::ExtractValue(const T &arg, wm_hkey_t *keyv) {
+@@ -387,54 +494,60 @@ CommandResponse WildcardMatch::ExtractValue(const T &arg, wm_hkey_t *keyv) {
  }
  
  int WildcardMatch::FindTuple(wm_hkey_t *mask) {
@@ -377,7 +385,7 @@ index ec639a7b..51e67c55 100644
    CommandResponse err = ExtractKeyMask(arg, &key, &mask);
    if (err.error().code() != 0) {
      return err;
-@@ -444,14 +558,13 @@ CommandResponse WildcardMatch::CommandAdd(
+@@ -444,14 +557,13 @@ CommandResponse WildcardMatch::CommandAdd(
      return CommandFailure(EINVAL, "Invalid gate: %hu", gate);
    }
  
@@ -393,7 +401,7 @@ index ec639a7b..51e67c55 100644
    int idx = FindTuple(&mask);
    if (idx < 0) {
      idx = AddTuple(&mask);
-@@ -459,13 +572,10 @@ CommandResponse WildcardMatch::CommandAdd(
+@@ -459,13 +571,10 @@ CommandResponse WildcardMatch::CommandAdd(
        return CommandFailure(-idx, "failed to add a new wildcard pattern");
      }
    }
@@ -410,7 +418,7 @@ index ec639a7b..51e67c55 100644
    return CommandSuccess();
  }
  
-@@ -485,7 +595,7 @@ CommandResponse WildcardMatch::CommandDelete(
+@@ -485,7 +594,7 @@ CommandResponse WildcardMatch::CommandDelete(
    }
  
    int ret = DelEntry(idx, &key);
@@ -419,7 +427,7 @@ index ec639a7b..51e67c55 100644
      return CommandFailure(-ret, "failed to delete a rule");
    }
  
-@@ -499,7 +609,10 @@ CommandResponse WildcardMatch::CommandClear(const bess::pb::EmptyArg &) {
+@@ -499,7 +608,10 @@ CommandResponse WildcardMatch::CommandClear(const bess::pb::EmptyArg &) {
  
  void WildcardMatch::Clear() {
    for (auto &tuple : tuples_) {
@@ -431,7 +439,7 @@ index ec639a7b..51e67c55 100644
    }
  }
  
-@@ -521,17 +634,26 @@ CommandResponse WildcardMatch::GetInitialArg(const bess::pb::EmptyArg &) {
+@@ -521,17 +633,26 @@ CommandResponse WildcardMatch::GetInitialArg(const bess::pb::EmptyArg &) {
  // Retrieves a WildcardMatchConfig that would restore this module's
  // runtime configuration.
  CommandResponse WildcardMatch::GetRuntimeConfig(const bess::pb::EmptyArg &) {
@@ -460,7 +468,7 @@ index ec639a7b..51e67c55 100644
        // Create the rule instance
        rule_t *rule = resp.add_rules();
        rule->set_priority(entry.second.priority);
-@@ -596,5 +718,14 @@ CommandResponse WildcardMatch::SetRuntimeConfig(
+@@ -596,5 +717,14 @@ CommandResponse WildcardMatch::SetRuntimeConfig(
    return CommandSuccess();
  }
  

--- a/patches/bess/0020-removed-dpdk-deprecated-option.patch
+++ b/patches/bess/0020-removed-dpdk-deprecated-option.patch
@@ -1,0 +1,13 @@
+diff --git a/core/dpdk.cc b/core/dpdk.cc
+index 964d513c..130572d7 100644
+--- a/core/dpdk.cc
++++ b/core/dpdk.cc
+@@ -112,7 +112,7 @@ class CmdLineOpts {
+ void init_eal(int dpdk_mb_per_socket, std::string nonworker_corelist) {
+   CmdLineOpts rte_args{
+       "bessd",
+-      "--master-lcore",
++      "--main-lcore",
+       std::to_string(RTE_MAX_LCORE - 1),
+       "--lcore",
+       std::to_string(RTE_MAX_LCORE - 1) + "@" + nonworker_corelist,

--- a/patches/bess/0020-removed-dpdk-deprecated-option.patch
+++ b/patches/bess/0020-removed-dpdk-deprecated-option.patch
@@ -11,3 +11,20 @@ index 964d513c..130572d7 100644
        std::to_string(RTE_MAX_LCORE - 1),
        "--lcore",
        std::to_string(RTE_MAX_LCORE - 1) + "@" + nonworker_corelist,
+diff --git a/core/memory_test.cc b/core/memory_test.cc
+index 9849147d..c5e44a16 100644
+--- a/core/memory_test.cc
++++ b/core/memory_test.cc
+@@ -139,9 +139,9 @@ TEST_P(HugepageTest, LeakFree) {
+   } while (get_cpu_time() - start < 0.5);  // 0.5 second for each page size
+ }
+ 
+-INSTANTIATE_TEST_CASE_P(PageSize, HugepageTest,
+-                        ::testing::Values(HugepageSize::k2MB,
+-                                          HugepageSize::k1GB));
++INSTANTIATE_TEST_SUITE_P(PageSize, HugepageTest,
++                         ::testing::Values(HugepageSize::k2MB,
++                                           HugepageSize::k1GB));
+ 
+ TEST(DmaMemoryPoolTest, PoolSetup) {
+   if (geteuid() != 0) {

--- a/patches/bess/0021-clean-up-cpp-code.patch
+++ b/patches/bess/0021-clean-up-cpp-code.patch
@@ -1,0 +1,109 @@
+diff --git a/bessctl/sugar.py b/bessctl/sugar.py
+index 86484d0c..0a883946 100644
+--- a/bessctl/sugar.py
++++ b/bessctl/sugar.py
+@@ -71,7 +71,7 @@ a:x->b               Connect output gate x of a    a*i + b
+ 
+ a->y:b               Connect a to input gate y     a + y*b
+                      of b                          a.connect(next_mod=b,
+-                     (x should be an integer)        igate=y)
++                     (y should be an integer)        igate=y)
+ 
+ a:3->4:b             Connect output gate 3 of a    a*3 + 4*b
+                      and input gate of 4           a.connect(next_mod=b,
+@@ -95,7 +95,7 @@ Ringo:
+ Python:
+     __bess_module__('a','Foo') + __bess_module__('b', 'Bar')
+ 
+-3. Create anonymous modules and connection them
++3. Create anonymous modules and connect them
+ Ringo:
+     Foo() -> Bar()
+ Python:
+diff --git a/core/memory_test.cc b/core/memory_test.cc
+index 9849147d..c5e44a16 100644
+--- a/core/memory_test.cc
++++ b/core/memory_test.cc
+@@ -139,9 +139,9 @@ TEST_P(HugepageTest, LeakFree) {
+   } while (get_cpu_time() - start < 0.5);  // 0.5 second for each page size
+ }
+ 
+-INSTANTIATE_TEST_CASE_P(PageSize, HugepageTest,
+-                        ::testing::Values(HugepageSize::k2MB,
+-                                          HugepageSize::k1GB));
++INSTANTIATE_TEST_SUITE_P(PageSize, HugepageTest,
++                         ::testing::Values(HugepageSize::k2MB,
++                                           HugepageSize::k1GB));
+ 
+ TEST(DmaMemoryPoolTest, PoolSetup) {
+   if (geteuid() != 0) {
+diff --git a/core/modules/measure.cc b/core/modules/measure.cc
+index e2b6dceb..5092fed4 100644
+--- a/core/modules/measure.cc
++++ b/core/modules/measure.cc
+@@ -63,16 +63,14 @@ const Commands Measure::cmds = {
+ CommandResponse Measure::Init(const bess::pb::MeasureArg &arg) {
+   uint64_t latency_ns_max = arg.latency_ns_max();
+   uint64_t latency_ns_resolution = arg.latency_ns_resolution();
+-  if (latency_ns_max == 0) {
++  if (!latency_ns_max) {
+     latency_ns_max = kDefaultMaxNs;
+   }
+-  if (latency_ns_resolution == 0) {
++  if (!latency_ns_resolution) {
+     latency_ns_resolution = kDefaultNsPerBucket;
+   }
+-  uint64_t quotient = latency_ns_max / latency_ns_resolution;
+-  if ((latency_ns_max % latency_ns_resolution) != 0) {
+-    quotient += 1;  // absorb any remainder
+-  }
++  uint64_t quotient = (latency_ns_max + latency_ns_resolution - 1) / latency_ns_resolution;
++
+   if (quotient > rtt_hist_.max_num_buckets() / 2) {
+     return CommandFailure(E2BIG,
+                           "excessive latency_ns_max / latency_ns_resolution");
+diff --git a/core/modules/source.cc b/core/modules/source.cc
+index db99dbc2..4b0413a0 100644
+--- a/core/modules/source.cc
++++ b/core/modules/source.cc
+@@ -45,7 +45,6 @@ CommandResponse Source::Init(const bess::pb::SourceArg &arg) {
+     return CommandFailure(ENOMEM, "Task creation failed");
+ 
+   pkt_size_ = 60;
+-  burst_ = bess::PacketBatch::kMaxBurst;
+ 
+   if (arg.pkt_size() > 0) {
+     if (arg.pkt_size() > SNBUF_DATA) {
+diff --git a/core/packet.cc b/core/packet.cc
+index a3656b52..8c5a5b8a 100644
+--- a/core/packet.cc
++++ b/core/packet.cc
+@@ -94,7 +94,6 @@ static std::string HexDump(const void *buffer, size_t len) {
+ std::string Packet::Dump() {
+   std::ostringstream dump;
+   Packet *pkt;
+-  uint32_t dump_len = total_len();
+   uint32_t nb_segs;
+   uint32_t len;
+ 
+@@ -142,7 +141,6 @@ std::string Packet::Dump() {
+       dump << HexDump(head_data(), len);
+     }
+ 
+-    dump_len -= len;
+     pkt = pkt->next_;
+     nb_segs--;
+   }
+diff --git a/core/utils/histogram.h b/core/utils/histogram.h
+index 7fbe2ba5..5fe654a6 100644
+--- a/core/utils/histogram.h
++++ b/core/utils/histogram.h
+@@ -191,7 +191,7 @@ class Histogram {
+   // Resize the histogram.  Note that this resets it (i.e., this
+   // does not attempt to redistribute existing counts).
+   void Resize(size_t num_buckets, T bucket_width) {
+-    buckets_ = std::move(std::vector<std::atomic<uint64_t>>(num_buckets + 1));
++    buckets_ = std::vector<std::atomic<uint64_t>>(num_buckets + 1);
+     bucket_width_ = bucket_width;
+   }
+ 

--- a/patches/bess/0021-clean-up-cpp-code.patch
+++ b/patches/bess/0021-clean-up-cpp-code.patch
@@ -20,23 +20,6 @@ index 86484d0c..0a883946 100644
  Ringo:
      Foo() -> Bar()
  Python:
-diff --git a/core/memory_test.cc b/core/memory_test.cc
-index 9849147d..c5e44a16 100644
---- a/core/memory_test.cc
-+++ b/core/memory_test.cc
-@@ -139,9 +139,9 @@ TEST_P(HugepageTest, LeakFree) {
-   } while (get_cpu_time() - start < 0.5);  // 0.5 second for each page size
- }
- 
--INSTANTIATE_TEST_CASE_P(PageSize, HugepageTest,
--                        ::testing::Values(HugepageSize::k2MB,
--                                          HugepageSize::k1GB));
-+INSTANTIATE_TEST_SUITE_P(PageSize, HugepageTest,
-+                         ::testing::Values(HugepageSize::k2MB,
-+                                           HugepageSize::k1GB));
- 
- TEST(DmaMemoryPoolTest, PoolSetup) {
-   if (geteuid() != 0) {
 diff --git a/core/modules/measure.cc b/core/modules/measure.cc
 index e2b6dceb..5092fed4 100644
 --- a/core/modules/measure.cc

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -178,7 +178,7 @@ func LoadConfigFile(filepath string) (Conf, error) {
 	defer jsonFile.Close()
 
 	// Read our file into memory.
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	if err != nil {
 		return Conf{}, err
 	}

--- a/pfcpiface/config_test.go
+++ b/pfcpiface/config_test.go
@@ -5,7 +5,7 @@ package pfcpiface
 
 import (
 	"io/fs"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -15,7 +15,7 @@ import (
 )
 
 func mustWriteStringToDisk(s string, path string) {
-	err := ioutil.WriteFile(path, []byte(s), fs.ModePerm)
+	err := os.WriteFile(path, []byte(s), fs.ModePerm)
 	if err != nil {
 		panic(err)
 	}

--- a/pfcpiface/p4rtc.go
+++ b/pfcpiface/p4rtc.go
@@ -6,7 +6,6 @@ package pfcpiface
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -473,7 +472,7 @@ func GetPipelineConfig(client p4.P4RuntimeClient, deviceID uint64) (*p4.GetForwa
 func (c *P4rtClient) SetForwardingPipelineConfig(p4InfoPath, deviceConfigPath string) (err error) {
 	log.Println("P4 Info: ", p4InfoPath)
 
-	p4infoBytes, err := ioutil.ReadFile(p4InfoPath)
+	p4infoBytes, err := os.ReadFile(p4InfoPath)
 	if err != nil {
 		log.Println("Read p4info file error ", err)
 		return

--- a/pfcpiface/web_service.go
+++ b/pfcpiface/web_service.go
@@ -5,7 +5,7 @@ package pfcpiface
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 
@@ -50,7 +50,7 @@ func (c *ConfigHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "PUT":
 		fallthrough
 	case "POST":
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			log.Errorln("http req read body failed.")
 			sendHTTPResp(http.StatusBadRequest, w)

--- a/scripts/docker_setup.sh
+++ b/scripts/docker_setup.sh
@@ -21,38 +21,38 @@ mode="dpdk"
 
 # Gateway interface(s)
 #
-# In the order of ("s1u" "sgi")
+# In the order of ("s1u/n3" "sgi/n6")
 ifaces=("ens803f2" "ens803f3")
 
 # Static IP addresses of gateway interface(s) in cidr format
 #
-# In the order of (s1u sgi)
+# In the order of (s1u/n3 sgi/n6)
 ipaddrs=(198.18.0.1/30 198.19.0.1/30)
 
 # MAC addresses of gateway interface(s)
 #
-# In the order of (s1u sgi)
+# In the order of (s1u/n3 sgi/n6)
 macaddrs=(9e:b2:d3:34:ab:27 c2:9c:55:d4:8a:f6)
 
 # Static IP addresses of the neighbors of gateway interface(s)
 #
-# In the order of (n-s1u n-sgi)
+# In the order of (n-s1u/n3 n-sgi/n6)
 nhipaddrs=(198.18.0.2 198.19.0.2)
 
 # Static MAC addresses of the neighbors of gateway interface(s)
 #
-# In the order of (n-s1u n-sgi)
+# In the order of (n-s1u/n3 n-sgi/n6)
 nhmacaddrs=(22:53:7a:15:58:50 22:53:7a:15:58:50)
 
 # IPv4 route table entries in cidr format per port
 #
-# In the order of ("{r-s1u}" "{r-sgi}")
+# In the order of ("{r-s1u/n3}" "{r-sgi/n6}")
 routes=("11.1.1.128/25" "0.0.0.0/0")
 
 num_ifaces=${#ifaces[@]}
 num_ipaddrs=${#ipaddrs[@]}
 
-# Set up static route and neighbor table entries of the SPGW
+# Set up static route and neighbor table entries of the UPF/SPGW
 function setup_trafficgen_routes() {
 	for ((i = 0; i < num_ipaddrs; i++)); do
 		sudo ip netns exec pause ip neighbor add "${nhipaddrs[$i]}" lladdr "${nhmacaddrs[$i]}" dev "${ifaces[$i % num_ifaces]}"


### PR DESCRIPTION
This PR includes a few things related to code cleanup:
- Remove unnecessary `endl` in loggings
- Update code relate to the `ioutil` package, which was deprecated in Go.1.16 (https://pkg.go.dev/io/ioutil)
- Add missing `override` keyword in the QoS class
- Fix `stringstream` in flow_measure.h
- Remove deprecated DPDK option/method and unused variables
- Fix a couple documentation typos
- Modify some comments in build_docker.sh script to mention N3 and N6 interfaces
- Modify accordingly some modules' names for the up4 pipeline