### PR TITLE
Address issue golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,6 +14,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>1.17'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.3.1

--- a/pfcpiface/p4rtc.go
+++ b/pfcpiface/p4rtc.go
@@ -31,7 +31,7 @@ import (
 // P4DeviceConfig ... Device config.
 type P4DeviceConfig []byte
 
-const invalidID = 0
+const invalidID = 0 //nolint:unused
 
 // Table Entry Function Type.
 const (


### PR DESCRIPTION
`golangci-lint` is failing in all of the open PRs. When reading the [documentation](https://github.com/golangci/golangci-lint-action#compatibility), v3.0.0+ requires explicit setup-go installation step prior to using this action: uses: actions/setup-go@v3

```markdown
# Compatibility
v3.0.0+ requires explicit setup-go installation step prior to using this action: uses: actions/setup-go@v3. The skip-go-installation option has been removed.
```

This PR includes:
- Updated steps for this GitHub Action
- Add `//nolint:unused` to a variable to address a "false positive" when running this GitHub Action

**Note: This PR is needed for all the other PRs**