### PR TITLE
Increase test timeout to 15m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ test-up4-integration-docker: DOCKER_TAG=integration
 test-up4-integration-docker: docker-build
 	docker rm -f mock-up4 pfcpiface
 	docker network prune -f
-	MODE=docker DATAPATH=up4 go test -v -count=1 -failfast ./test/integration/...
+	MODE=docker DATAPATH=up4 go test -v -count=1 -failfast -timeout 15m ./test/integration/...
 
 test-bess-integration-native:
 	MODE=native DATAPATH=bess go test \


### PR DESCRIPTION
Several times, the `test-integration-up4-docker` test (part of the "E2E integration tests / test-integration-bess-native (pull_request)" check) fails because the test takes longer than 10mins to complete.
As per the `go test` documentation, the default `timeout` is 10mins. So, this PR increases the timeout time to 15mins
```bash
$ go help testflag
The 'go test' command takes both flags that apply to 'go test' itself
and flags that apply to the resulting test binary.
...
...
        -timeout d
            If a test binary runs longer than duration d, panic.
            If d is 0, the timeout is disabled.
            The default is 10 minutes (10m).
...
```