### PR TITLE
Temporarily reverting PR698 until issue is addressed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN ./build_bess.sh && \
     cp -r core/pb /pb
 
 # Stage bess: creates the runtime image of BESS
-FROM python:3.11.4-slim AS bess
+FROM python:3.11.3-slim AS bess
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         gcc \


### PR DESCRIPTION
This issue should close #701 and a solution needs to be found to be able to use an update image such as python:3.11.4-slim