### PR TITLE
Added support to configure UL/DL MBR via config in sim mode

### DIFF
--- a/conf/upf.json
+++ b/conf/upf.json
@@ -36,10 +36,10 @@
         "start_n3_teid": "0x30000000",
         "start_n9_teid": "0x90000000",
 	"uplink_mbr": 500000,
-	"": "Make sure uplink_gbr is configured less than uplink_mbr",
+	"": "Make sure uplink_gbr is configured less than uplink_mbr if 'qfi' in pfcpiface/grpcsim.go is for GBR flows. Current default value is for Non-GBR flows",
 	"uplink_gbr": 50000,
 	"downlink_mbr": 1000000,
-	"": "Make sure downlink_gbr is configured less than downlink_mbr",
+	"": "Make sure downlink_gbr is configured less than downlink_mbr if 'qfi' in pfcpiface/grpcsim.go is for GBR flows. Current default value is for Non-GBR flows",
 	"downlink_gbr": 100000,
         "pkt_size": 128,
         "total_flows": 5000

--- a/conf/upf.json
+++ b/conf/upf.json
@@ -35,6 +35,8 @@
         "n9_app_ip": "9.9.9.9",
         "start_n3_teid": "0x30000000",
         "start_n9_teid": "0x90000000",
+	"uplink_mbr": 500000,
+	"downlink_mbr": 1000000,
         "pkt_size": 128,
         "total_flows": 5000
     },

--- a/conf/upf.json
+++ b/conf/upf.json
@@ -36,7 +36,11 @@
         "start_n3_teid": "0x30000000",
         "start_n9_teid": "0x90000000",
 	"uplink_mbr": 500000,
+	"": "Make sure uplink_gbr is configured less than uplink_mbr",
+	"uplink_gbr": 50000,
 	"downlink_mbr": 1000000,
+	"": "Make sure downlink_gbr is configured less than downlink_mbr",
+	"downlink_gbr": 100000,
         "pkt_size": 128,
         "total_flows": 5000
     },

--- a/conf/upf.json
+++ b/conf/upf.json
@@ -36,10 +36,10 @@
         "start_n3_teid": "0x30000000",
         "start_n9_teid": "0x90000000",
 	"uplink_mbr": 500000,
-	"": "Make sure uplink_gbr is configured less than uplink_mbr if 'qfi' in pfcpiface/grpcsim.go is for GBR flows. Current default value is for Non-GBR flows",
+	"": "Make sure uplink_gbr is configured less than uplink_mbr if 'qfi' in pfcpiface/grpcsim.go is for GBR flows. Current default 'qfi' value is for Non-GBR flows",
 	"uplink_gbr": 50000,
 	"downlink_mbr": 1000000,
-	"": "Make sure downlink_gbr is configured less than downlink_mbr if 'qfi' in pfcpiface/grpcsim.go is for GBR flows. Current default value is for Non-GBR flows",
+	"": "Make sure downlink_gbr is configured less than downlink_mbr if 'qfi' in pfcpiface/grpcsim.go is for GBR flows. Current default 'qfi' value is for Non-GBR flows",
 	"downlink_gbr": 100000,
         "pkt_size": 128,
         "total_flows": 5000

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -75,6 +75,8 @@ type SimModeInfo struct {
 	N9AppIP     net.IP `json:"n9_app_ip"`
 	StartN3TEID string `json:"start_n3_teid"`
 	StartN9TEID string `json:"start_n9_teid"`
+	UplinkMBR   uint64 `json:"uplink_mbr"`
+	DownlinkMBR uint64 `json:"downlink_mbr"`
 }
 
 // CPIfaceInfo : CPIface interface settings.

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -77,6 +77,8 @@ type SimModeInfo struct {
 	StartN9TEID string `json:"start_n9_teid"`
 	UplinkMBR   uint64 `json:"uplink_mbr"`
 	DownlinkMBR uint64 `json:"downlink_mbr"`
+	UplinkGBR   uint64 `json:"uplink_gbr"`
+	DownlinkGBR uint64 `json:"downlink_gbr"`
 }
 
 // CPIfaceInfo : CPIface interface settings.

--- a/pfcpiface/grpcsim.go
+++ b/pfcpiface/grpcsim.go
@@ -221,9 +221,9 @@ func (u *upf) sim(mode simMode, s *SimModeInfo) {
 			qerID: n6,
 			fseID: uint64(n3TEID + i),
 			qfi:   9,
-			ulGbr: 50000,
+			ulGbr: s.UplinkGBR,
 			ulMbr: s.UplinkMBR,
-			dlGbr: 60000,
+			dlGbr: s.DownlinkGBR,
 			dlMbr: s.DownlinkMBR,
 		}
 
@@ -231,9 +231,9 @@ func (u *upf) sim(mode simMode, s *SimModeInfo) {
 			qerID: n9,
 			fseID: uint64(n3TEID + i),
 			qfi:   8,
-			ulGbr: 50000,
+			ulGbr: s.UplinkGBR,
 			ulMbr: s.UplinkMBR,
-			dlGbr: 70000,
+			dlGbr: s.DownlinkGBR,
 			dlMbr: s.DownlinkMBR,
 		}
 
@@ -245,10 +245,10 @@ func (u *upf) sim(mode simMode, s *SimModeInfo) {
 			fseID:    uint64(n3TEID + i),
 			qosLevel: SessionQos,
 			qfi:      0,
-			ulGbr:    0,
-			ulMbr:    100000,
-			dlGbr:    0,
-			dlMbr:    500000,
+			ulGbr:    s.UplinkGBR,
+			ulMbr:    s.UplinkMBR,
+			dlGbr:    s.DownlinkGBR,
+			dlMbr:    s.DownlinkMBR,
 		}
 
 		qers = append(qers, sessionQer)

--- a/pfcpiface/grpcsim.go
+++ b/pfcpiface/grpcsim.go
@@ -217,6 +217,8 @@ func (u *upf) sim(mode simMode, s *SimModeInfo) {
 		fars := []far{farDown, farN6Up, farN9Up}
 
 		// create/delete uplink qer
+		// For Non-GBR flows, the ulGbr/dlGbr values assigend
+		// below is ignored and has no impact
 		qerN6 := qer{
 			qerID: n6,
 			fseID: uint64(n3TEID + i),
@@ -227,6 +229,8 @@ func (u *upf) sim(mode simMode, s *SimModeInfo) {
 			dlMbr: s.DownlinkMBR,
 		}
 
+		// For Non-GBR flows, the ulGbr/dlGbr values assigend
+		// below is ignored and has no impact
 		qerN9 := qer{
 			qerID: n9,
 			fseID: uint64(n3TEID + i),

--- a/pfcpiface/grpcsim.go
+++ b/pfcpiface/grpcsim.go
@@ -222,9 +222,9 @@ func (u *upf) sim(mode simMode, s *SimModeInfo) {
 			fseID: uint64(n3TEID + i),
 			qfi:   9,
 			ulGbr: 50000,
-			ulMbr: 90000,
+			ulMbr: s.UplinkMBR,
 			dlGbr: 60000,
-			dlMbr: 80000,
+			dlMbr: s.DownlinkMBR,
 		}
 
 		qerN9 := qer{
@@ -232,9 +232,9 @@ func (u *upf) sim(mode simMode, s *SimModeInfo) {
 			fseID: uint64(n3TEID + i),
 			qfi:   8,
 			ulGbr: 50000,
-			ulMbr: 60000,
+			ulMbr: s.UplinkMBR,
 			dlGbr: 70000,
-			dlMbr: 90000,
+			dlMbr: s.DownlinkMBR,
 		}
 
 		qers := []qer{qerN6, qerN9}


### PR DESCRIPTION
Added Uplink/Downlink MBR rate config to the sim section in upf.json. This will allow the user to configure the rate as per the need.