### PR TITLE
Add one step to GHA jobs to cleanup unused images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,10 @@ jobs:
       run: |
         make docker-build
         make docker-push
+    # Cleanup space due to runners limited storage
+    - name: Cleanup Docker images
+      run: |
+        docker image prune -af
 
   push-dockerhub:
     env:
@@ -54,6 +58,10 @@ jobs:
           docker pull ${DOCKER_REPOSITORY}upf-epc-pfcpiface:$DOCKER_TAG
           CPU=$CPU make docker-build
           make docker-push
+      # Cleanup space due to runners limited storage
+      - name: Cleanup Docker images
+        run: |
+          docker image prune -f
 
       - name: Build and push "master-GIT_SHA" Docker images for Haswell CPU
         env:
@@ -62,6 +70,10 @@ jobs:
         run: |
           CPU=$CPU make docker-build
           make docker-push
+      # Cleanup space due to runners limited storage
+      - name: Cleanup Docker images
+        run: |
+          docker image prune -f
 
       - name: Build and push "master-latest-ivybridge" Docker images for Ivybridge CPU
         env:
@@ -72,6 +84,10 @@ jobs:
           docker pull ${DOCKER_REPOSITORY}upf-epc-pfcpiface:$DOCKER_TAG
           CPU=$CPU make docker-build
           make docker-push
+      # Cleanup space due to runners limited storage
+      - name: Cleanup Docker images
+        run: |
+          docker image prune -f
 
       - name: Build and push "master-GIT_SHA-ivybridge" Docker images for Ivybridge CPU
         env:
@@ -80,3 +96,7 @@ jobs:
         run: |
           CPU=$CPU make docker-build
           make docker-push
+      # Cleanup space due to runners limited storage
+      - name: Cleanup Docker images
+        run: |
+          docker image prune -f


### PR DESCRIPTION
Add one more step to GHA jobs to cleanup unused images due to limited storage in the GitHub runners