### PR TITLE
Enable go lint CI in all directories

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,4 +22,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3.7.0
         with:
           version: latest
-          args: -v --config ../.golangci.yml
+          args: -v --config ./.golangci.yml

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,8 +19,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.6.0
+        uses: golangci/golangci-lint-action@v3.7.0
         with:
           version: latest
-          working-directory: pfcpiface
           args: -v --config ../.golangci.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,15 +10,39 @@ run:
     - ".*\\.pb\\.go"
   skip-dirs-use-default: true
 
+# all available settings of specific linters
+linters-settings:
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+    # settings per analyzer
+    settings:
+      printf: # analyzer name, run `go tool vet help` to see all analyzers
+        funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+    # enable all analyzers
+    enable-all: true
+    disable:
+      - fieldalignment
+
 linters:
   enable:
     - goconst
-    - goerr113
     - gofmt
     - goimports
-    - gosec
+    - govet
+    - ineffassign
     - misspell
     - nilerr
     - nilnil
     - unparam
+
+  disable:
+    - errcheck
+    - goerr113
+    - gosec
+    - staticcheck
     - wsl

--- a/cmd/p4info_code_gen/p4info_code_gen.go
+++ b/cmd/p4info_code_gen/p4info_code_gen.go
@@ -7,13 +7,15 @@ import (
 	"encoding/binary"
 	"flag"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"sort"
 	"strings"
 
 	"github.com/ettle/strcase"
 	"github.com/golang/protobuf/proto"
+
+	log "github.com/sirupsen/logrus"
+
 	p4ConfigV1 "github.com/p4lang/p4runtime/go/p4/config/v1"
 )
 

--- a/cmd/pfcpiface/main.go
+++ b/cmd/pfcpiface/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"flag"
+
 	"github.com/omec-project/upf-epc/pfcpiface"
 	log "github.com/sirupsen/logrus"
 )

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -738,7 +738,8 @@ func (b *bess) clearState() {
 	clearGtpuPathMonitoringCmd := &pb.GtpuPathMonitoringCommandClearArg{}
 
 	if enableGtpuPathMonitoring {
-		anyGtpuPathMonitoringClear, err := anypb.New(clearGtpuPathMonitoringCmd)
+		var anyGtpuPathMonitoringClear *anypb.Any
+		anyGtpuPathMonitoringClear, err = anypb.New(clearGtpuPathMonitoringCmd)
 		if err != nil {
 			log.Errorf("Error marshalling the rule %v: %v", anyGtpuPathMonitoringClear, err)
 			return
@@ -748,18 +749,18 @@ func (b *bess) clearState() {
 	}
 
 	clearQoSCmd := &pb.QosCommandClearArg{}
-
-	anyQoSClear, err := anypb.New(clearQoSCmd)
+	var anyQoSClear *anypb.Any
+	anyQoSClear, err = anypb.New(clearQoSCmd)
 	if err != nil {
 		log.Errorf("Error marshalling the rule %v: %v", anyQoSClear, err)
 		return
 	}
 
-	if err := b.processQER(ctx, anyQoSClear, upfMsgTypeClear, AppQerLookup); err != nil {
+	if err = b.processQER(ctx, anyQoSClear, upfMsgTypeClear, AppQerLookup); err != nil {
 		log.Errorf("Failed to clear %v", AppQerLookup)
 	}
 
-	if err := b.processQER(ctx, anyQoSClear, upfMsgTypeClear, SessQerLookup); err != nil {
+	if err = b.processQER(ctx, anyQoSClear, upfMsgTypeClear, SessQerLookup); err != nil {
 		log.Errorf("Failed to clear %v", SessQerLookup)
 	}
 }

--- a/pfcpiface/ip_pool.go
+++ b/pfcpiface/ip_pool.go
@@ -31,7 +31,7 @@ func NewIPPool(poolSubnet string) (*IPPool, error) {
 		inventory: make(map[uint64]net.IP),
 	}
 
-	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
+	for ip = ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
 		ipVal := make(net.IP, len(ip))
 		copy(ipVal, ip)
 		i.freePool = append(i.freePool, ipVal)

--- a/pfcpiface/ip_pool_test.go
+++ b/pfcpiface/ip_pool_test.go
@@ -74,8 +74,9 @@ func TestIPPool_LookupOrAllocIP(t *testing.T) {
 		pool, err := NewIPPool(poolSubnet)
 		require.NoError(t, err)
 		seidToIpMap := map[uint64]net.IP{}
+		var ip net.IP
 		for i := uint64(0); i < usableAddresses; i++ {
-			ip, err := pool.LookupOrAllocIP(baseSeid + i)
+			ip, err = pool.LookupOrAllocIP(baseSeid + i)
 			require.NoError(t, err)
 			seidToIpMap[baseSeid+i] = ip
 		}

--- a/pfcpiface/messages_conn.go
+++ b/pfcpiface/messages_conn.go
@@ -266,7 +266,7 @@ func (pConn *PFCPConn) handlePFDMgmtRequest(msg message.Message) (message.Messag
 		}
 
 		pConn.NewAppPFD(id)
-		appPFD := pConn.appPFDs[id]
+		applicationPFD := pConn.appPFDs[id]
 
 		pfdCtx, err := appIDPFD.PFDContext()
 		if err != nil {
@@ -285,11 +285,11 @@ func (pConn *PFCPConn) handlePFDMgmtRequest(msg message.Message) (message.Messag
 				return errUnmarshalReply(errFlowDescAbsent, appIDPFD)
 			}
 
-			appPFD.flowDescs = append(appPFD.flowDescs, fields.FlowDescription)
+			applicationPFD.flowDescs = append(applicationPFD.flowDescs, fields.FlowDescription)
 		}
 
-		pConn.appPFDs[id] = appPFD
-		log.Traceln("Flow descriptions for AppID", id, ":", appPFD.flowDescs)
+		pConn.appPFDs[id] = applicationPFD
+		log.Traceln("Flow descriptions for AppID", id, ":", applicationPFD.flowDescs)
 	}
 
 	// Build response message

--- a/pfcpiface/messages_session.go
+++ b/pfcpiface/messages_session.go
@@ -88,7 +88,7 @@ func (pConn *PFCPConn) handleSessionEstablishmentRequest(msg message.Message) (m
 
 	for _, cPDR := range sereq.CreatePDR {
 		var p pdr
-		if err := p.parsePDR(cPDR, session.localSEID, pConn.appPFDs, upf.ippool); err != nil {
+		if err = p.parsePDR(cPDR, session.localSEID, pConn.appPFDs, upf.ippool); err != nil {
 			return errProcessReply(err, ie.CauseRequestRejected)
 		}
 
@@ -99,7 +99,7 @@ func (pConn *PFCPConn) handleSessionEstablishmentRequest(msg message.Message) (m
 
 	for _, cFAR := range sereq.CreateFAR {
 		var f far
-		if err := f.parseFAR(cFAR, session.localSEID, upf, create); err != nil {
+		if err = f.parseFAR(cFAR, session.localSEID, upf, create); err != nil {
 			return errProcessReply(err, ie.CauseRequestRejected)
 		}
 
@@ -110,7 +110,7 @@ func (pConn *PFCPConn) handleSessionEstablishmentRequest(msg message.Message) (m
 
 	for _, cQER := range sereq.CreateQER {
 		var q qer
-		if err := q.parseQER(cQER, session.localSEID); err != nil {
+		if err = q.parseQER(cQER, session.localSEID); err != nil {
 			return errProcessReply(err, ie.CauseRequestRejected)
 		}
 

--- a/pfcpiface/p4rtc.go
+++ b/pfcpiface/p4rtc.go
@@ -234,6 +234,7 @@ func (c *P4rtClient) ReadTableEntry(entry *p4.TableEntry) (*p4.ReadResponse, err
 
 // ReadReqEntities ... Read request Entity.
 func (c *P4rtClient) ReadReqEntities(entities []*p4.Entity) (*p4.ReadResponse, error) {
+	var readRes *p4.ReadResponse
 	req := &p4.ReadRequest{
 		DeviceId: c.deviceID,
 		Entities: entities,
@@ -242,7 +243,7 @@ func (c *P4rtClient) ReadReqEntities(entities []*p4.Entity) (*p4.ReadResponse, e
 
 	readClient, err := c.client.Read(context.Background(), req)
 	if err == nil {
-		readRes, err := readClient.Recv()
+		readRes, err = readClient.Recv()
 		if err == nil {
 			log.Traceln(proto.MarshalTextString(readRes))
 			return readRes, nil
@@ -255,6 +256,7 @@ func (c *P4rtClient) ReadReqEntities(entities []*p4.Entity) (*p4.ReadResponse, e
 // ReadReq ... Read Request.
 func (c *P4rtClient) ReadReq(entity *p4.Entity) (*p4.ReadResponse, error) {
 	var req p4.ReadRequest
+	var readRes *p4.ReadResponse
 	req.DeviceId = c.deviceID
 	req.Entities = []*p4.Entity{entity}
 
@@ -266,7 +268,7 @@ func (c *P4rtClient) ReadReq(entity *p4.Entity) (*p4.ReadResponse, error) {
 
 	readClient, err := c.client.Read(ctx, &req)
 	if err == nil {
-		readRes, err := readClient.Recv()
+		readRes, err = readClient.Recv()
 		if err == nil {
 			log.Traceln(proto.MarshalTextString(readRes))
 			return readRes, nil
@@ -589,7 +591,7 @@ func CreateChannel(host string, deviceID uint64) (*P4rtClient, error) {
 
 	closeStreamOnError := func() {
 		if client.stream != nil {
-			err := client.stream.CloseSend()
+			err = client.stream.CloseSend()
 			if err != nil {
 				log.Errorf("Failed to close P4Rt stream with %v: %v", client.conn.Target(), err)
 			}

--- a/pfcpiface/parse_far.go
+++ b/pfcpiface/parse_far.go
@@ -106,13 +106,14 @@ func (f *far) parseFAR(farIE *ie.IE, fseid uint64, upf *upf, op operation) error
 	f.sendEndMarker = false
 
 	var fields Bits
+	var ohcFields *ie.OuterHeaderCreationFields
 
 	for _, fwdIE := range fwdIEs {
 		switch fwdIE.Type {
 		case ie.OuterHeaderCreation:
 			fields = Set(fields, FwdIEOuterHeaderCreation)
 
-			ohcFields, err := fwdIE.OuterHeaderCreation()
+			ohcFields, err = fwdIE.OuterHeaderCreation()
 			if err != nil {
 				log.Println("Unable to parse OuterHeaderCreationFields!")
 				continue

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -92,6 +92,7 @@ func NewUPF(conf *Conf, fp datapath) *upf {
 	var (
 		err    error
 		nodeID string
+		hosts  []string
 	)
 
 	nodeID = conf.CPIface.NodeID
@@ -104,7 +105,7 @@ func NewUPF(conf *Conf, fp datapath) *upf {
 
 	// TODO: Delete this once CI config is fixed
 	if nodeID != "" {
-		hosts, err := net.LookupHost(nodeID)
+		hosts, err = net.LookupHost(nodeID)
 		if err != nil {
 			log.Fatalln("Unable to resolve hostname", nodeID, err)
 		}

--- a/pkg/fake_bess/fake_bess.go
+++ b/pkg/fake_bess/fake_bess.go
@@ -5,9 +5,10 @@ package fake_bess
 
 import (
 	"fmt"
+	"net"
+
 	"github.com/omec-project/upf-epc/pfcpiface/bess_pb"
 	"google.golang.org/grpc"
-	"net"
 )
 
 type FakeBESS struct {

--- a/pkg/fake_bess/fake_bess_service.go
+++ b/pkg/fake_bess/fake_bess_service.go
@@ -6,6 +6,9 @@ package fake_bess
 import (
 	"context"
 	"fmt"
+	"math"
+	"sync"
+
 	"github.com/omec-project/upf-epc/pfcpiface/bess_pb"
 	"github.com/omec-project/upf-epc/pkg/utils"
 	log "github.com/sirupsen/logrus"
@@ -13,8 +16,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
-	"math"
-	"sync"
 )
 
 const (
@@ -23,6 +24,9 @@ const (
 	sessionQerModuleName         = "sessionQERLookup"
 	appQerModuleName             = "appQERLookup"
 	gtpuPathMonitoringModuleName = "gtpuPathMonitoring"
+	addCmd                       = "add"
+	clearCmd                     = "clear"
+	deleteCmd                    = "delete"
 )
 
 type FakePdr struct {
@@ -331,7 +335,7 @@ func (w *wildcardModule) HandleRequest(cmd string, arg *anypb.Any) (err error) {
 
 	log := log.WithField("module", w.Name()).WithField("cmd", cmd)
 
-	if cmd == "add" {
+	if cmd == addCmd {
 		wc := &bess_pb.WildcardMatchCommandAddArg{}
 		err = arg.UnmarshalTo(wc)
 		if err != nil {
@@ -352,7 +356,7 @@ func (w *wildcardModule) HandleRequest(cmd string, arg *anypb.Any) (err error) {
 			log.Tracef("added new entry %v", wc)
 			w.entries = append(w.entries, wc)
 		}
-	} else if cmd == "delete" {
+	} else if cmd == deleteCmd {
 		wc := &bess_pb.WildcardMatchCommandDeleteArg{}
 		err = arg.UnmarshalTo(wc)
 		if err != nil {
@@ -371,7 +375,7 @@ func (w *wildcardModule) HandleRequest(cmd string, arg *anypb.Any) (err error) {
 			log.Tracef("deleted existing entry %v", w.entries[idx])
 			w.entries = append(w.entries[:idx], w.entries[idx+1:]...)
 		}
-	} else if cmd == "clear" {
+	} else if cmd == clearCmd {
 		wc := &bess_pb.WildcardMatchCommandClearArg{}
 		err = arg.UnmarshalTo(wc)
 		if err != nil {
@@ -405,7 +409,7 @@ func (e *exactMatchModule) HandleRequest(cmd string, arg *anypb.Any) (err error)
 
 	log := log.WithField("module", e.Name()).WithField("cmd", cmd)
 
-	if cmd == "add" {
+	if cmd == addCmd {
 		em := &bess_pb.ExactMatchCommandAddArg{}
 		err = arg.UnmarshalTo(em)
 		if err != nil {
@@ -425,7 +429,7 @@ func (e *exactMatchModule) HandleRequest(cmd string, arg *anypb.Any) (err error)
 			log.Tracef("added new entry %v", em)
 			e.entries = append(e.entries, em)
 		}
-	} else if cmd == "delete" {
+	} else if cmd == deleteCmd {
 		em := &bess_pb.ExactMatchCommandDeleteArg{}
 		err = arg.UnmarshalTo(em)
 		if err != nil {
@@ -443,7 +447,7 @@ func (e *exactMatchModule) HandleRequest(cmd string, arg *anypb.Any) (err error)
 			log.Tracef("deleted existing entry %v", e.entries[idx])
 			e.entries = append(e.entries[:idx], e.entries[idx+1:]...)
 		}
-	} else if cmd == "clear" {
+	} else if cmd == clearCmd {
 		em := &bess_pb.ExactMatchCommandClearArg{}
 		err = arg.UnmarshalTo(em)
 		if err != nil {
@@ -477,7 +481,7 @@ func (q *qosModule) HandleRequest(cmd string, arg *anypb.Any) (err error) {
 
 	log := log.WithField("module", q.Name()).WithField("cmd", cmd)
 
-	if cmd == "add" {
+	if cmd == addCmd {
 		wc := &bess_pb.QosCommandAddArg{}
 		err = arg.UnmarshalTo(wc)
 		if err != nil {
@@ -497,7 +501,7 @@ func (q *qosModule) HandleRequest(cmd string, arg *anypb.Any) (err error) {
 			log.Tracef("added new entry %v", wc)
 			q.entries = append(q.entries, wc)
 		}
-	} else if cmd == "delete" {
+	} else if cmd == deleteCmd {
 		qc := &bess_pb.QosCommandDeleteArg{}
 		err = arg.UnmarshalTo(qc)
 		if err != nil {
@@ -515,7 +519,7 @@ func (q *qosModule) HandleRequest(cmd string, arg *anypb.Any) (err error) {
 			log.Tracef("deleted existing entry %v", q.entries[idx])
 			q.entries = append(q.entries[:idx], q.entries[idx+1:]...)
 		}
-	} else if cmd == "clear" {
+	} else if cmd == clearCmd {
 		qc := &bess_pb.QosCommandClearArg{}
 		err = arg.UnmarshalTo(qc)
 		if err != nil {
@@ -549,7 +553,7 @@ func (q *gtpuPathMonitoringModule) HandleRequest(cmd string, arg *anypb.Any) (er
 
 	log := log.WithField("module", q.Name()).WithField("cmd", cmd)
 
-	if cmd == "add" {
+	if cmd == addCmd {
 		wc := &bess_pb.GtpuPathMonitoringCommandAddDeleteArg{}
 		err = arg.UnmarshalTo(wc)
 		if err != nil {
@@ -569,7 +573,7 @@ func (q *gtpuPathMonitoringModule) HandleRequest(cmd string, arg *anypb.Any) (er
 			log.Tracef("added new entry %v", wc)
 			q.entries = append(q.entries, wc)
 		}
-	} else if cmd == "delete" {
+	} else if cmd == deleteCmd {
 		qc := &bess_pb.GtpuPathMonitoringCommandAddDeleteArg{}
 		err = arg.UnmarshalTo(qc)
 		if err != nil {
@@ -587,7 +591,7 @@ func (q *gtpuPathMonitoringModule) HandleRequest(cmd string, arg *anypb.Any) (er
 			log.Tracef("deleted existing entry %v", q.entries[idx])
 			q.entries = append(q.entries[:idx], q.entries[idx+1:]...)
 		}
-	} else if cmd == "clear" {
+	} else if cmd == clearCmd {
 		qc := &bess_pb.GtpuPathMonitoringCommandClearArg{}
 		err = arg.UnmarshalTo(qc)
 		if err != nil {
@@ -604,11 +608,11 @@ func (q *gtpuPathMonitoringModule) HandleRequest(cmd string, arg *anypb.Any) (er
 
 func isValidCommand(cmd string) bool {
 	switch cmd {
-	case "add":
+	case addCmd:
 		fallthrough
-	case "clear":
+	case clearCmd:
 		fallthrough
-	case "delete":
+	case deleteCmd:
 		return true
 	default:
 		return false

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -5,10 +5,11 @@ package utils
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"math"
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestInt2ip(t *testing.T) {

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -4,17 +4,17 @@
 package integration
 
 import (
-	"github.com/omec-project/upf-epc/internal/p4constants"
-	"github.com/omec-project/upf-epc/pfcpiface"
-	"github.com/wmnsk/go-pfcp/message"
 	"net"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/omec-project/pfcpsim/pkg/pfcpsim/session"
+	"github.com/omec-project/upf-epc/internal/p4constants"
+	"github.com/omec-project/upf-epc/pfcpiface"
 	"github.com/stretchr/testify/require"
 	"github.com/wmnsk/go-pfcp/ie"
+	"github.com/wmnsk/go-pfcp/message"
 )
 
 func TestUPFBasedUeIPAllocation(t *testing.T) {
@@ -117,7 +117,7 @@ func TestUPFBasedUeIPAllocation(t *testing.T) {
 	_, err = pfcpClient.PeekNextResponse()
 	require.NoError(t, err)
 
-	verifyNoEntries(t, testcase.expected)
+	verifyNoEntries(t)
 }
 
 func TestDetectUP4Restart(t *testing.T) {
@@ -125,7 +125,7 @@ func TestDetectUP4Restart(t *testing.T) {
 		t.Skipf("Skipping UP4-specific test for datapath: %s", os.Getenv(EnvDatapath))
 	}
 
-	run := func(t *testing.T) {
+	run := func() {
 		// restart UP4, it will close P4Runtime channel between pfcpiface and mock-up4
 		MustStopMockUP4()
 		MustStartMockUP4()
@@ -168,7 +168,7 @@ func TestDetectUP4Restart(t *testing.T) {
 		setup(t, ConfigDefault)
 		defer teardown(t)
 
-		run(t)
+		run()
 		// do not clear state on UP4 restart means that interfaces will not be re-installed.
 		// The assumption is that the ONOS cluster preserves them, but BMv2 doesn't.
 		verifyNumberOfEntries(t, p4constants.TablePreQosPipeInterfaces, 0)
@@ -178,7 +178,7 @@ func TestDetectUP4Restart(t *testing.T) {
 		setup(t, ConfigWipeOutOnUP4Restart)
 		defer teardown(t)
 
-		run(t)
+		run()
 		// clear state on UP4 restart means that interfaces entries will be re-installed.
 		verifyNumberOfEntries(t, p4constants.TablePreQosPipeInterfaces, 2)
 	})
@@ -667,7 +667,7 @@ func testUEDetach(t *testing.T, testcase *testCase) {
 	err := pfcpClient.DeleteSession(testcase.session)
 	require.NoErrorf(t, err, "failed to delete PFCP session")
 
-	verifyNoEntries(t, testcase.expected)
+	verifyNoEntries(t)
 }
 
 func testUEAttachDetach(t *testing.T, testcase *testCase) {

--- a/test/integration/conf.go
+++ b/test/integration/conf.go
@@ -6,11 +6,12 @@ package integration
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/omec-project/upf-epc/pfcpiface"
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"runtime"
+
+	"github.com/omec-project/upf-epc/pfcpiface"
+	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -6,6 +6,11 @@ package integration
 import (
 	"encoding/json"
 	"errors"
+	"net"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/omec-project/pfcpsim/pkg/pfcpsim"
 	"github.com/omec-project/upf-epc/internal/p4constants"
 	"github.com/omec-project/upf-epc/pfcpiface"
@@ -16,10 +21,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/wmnsk/go-pfcp/ie"
-	"net"
-	"os"
-	"testing"
-	"time"
 )
 
 // this file should contain all the struct defs/constants used among different test cases.
@@ -388,7 +389,7 @@ func verifyEntries(t *testing.T, testdata *pfcpSessionData, expectedValues p4RtV
 	case DatapathUP4:
 		verifyP4RuntimeEntries(t, testdata, expectedValues, ueState)
 	case DatapathBESS:
-		verifyBessEntries(t, bessFake, testdata, expectedValues, ueState)
+		verifyBessEntries(t, bessFake, expectedValues)
 	}
 }
 
@@ -401,10 +402,10 @@ func verifySliceMeter(t *testing.T, expectedValues p4RtValues) {
 	}
 }
 
-func verifyNoEntries(t *testing.T, expectedValues p4RtValues) {
+func verifyNoEntries(t *testing.T) {
 	switch os.Getenv(EnvDatapath) {
 	case DatapathUP4:
-		verifyNoP4RuntimeEntries(t, expectedValues)
+		verifyNoP4RuntimeEntries(t)
 	case DatapathBESS:
 		verifyNoBessRuntimeEntries(t, bessFake)
 	}

--- a/test/integration/providers/docker.go
+++ b/test/integration/providers/docker.go
@@ -7,6 +7,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log"
+	"os/exec"
+	"strings"
+	"time"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
@@ -14,11 +20,6 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/sirupsen/logrus"
-	"io"
-	"log"
-	"os/exec"
-	"strings"
-	"time"
 )
 
 // MustRunDockerCommandAttach attaches to a running Docker container and executes a cmd.
@@ -32,7 +33,7 @@ func MustRunDockerCommandAttach(container string, cmd string) {
 	}
 	defer cli.Close()
 
-	waiter, err := cli.ContainerAttach(ctx, container, types.ContainerAttachOptions{
+	waiter, _ := cli.ContainerAttach(ctx, container, types.ContainerAttachOptions{
 		Stderr: true,
 		Stdout: true,
 		Stdin:  true,

--- a/test/integration/providers/docker.go
+++ b/test/integration/providers/docker.go
@@ -33,12 +33,15 @@ func MustRunDockerCommandAttach(container string, cmd string) {
 	}
 	defer cli.Close()
 
-	waiter, _ := cli.ContainerAttach(ctx, container, types.ContainerAttachOptions{
+	waiter, err := cli.ContainerAttach(ctx, container, types.ContainerAttachOptions{
 		Stderr: true,
 		Stdout: true,
 		Stdin:  true,
 		Stream: true,
 	})
+	if err != nil {
+		logrus.Fatalf("Failed to attach container: %v", err)
+	}
 	defer waiter.Close()
 	if err = waiter.Conn.SetWriteDeadline(time.Now().Add(time.Second * 1)); err != nil {
 		logrus.Fatalf("Failed to set deadline: %v", err)

--- a/test/integration/providers/p4runtime.go
+++ b/test/integration/providers/p4runtime.go
@@ -6,11 +6,13 @@ package providers
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/antoninbas/p4runtime-go-client/pkg/client"
-	p4_v1 "github.com/p4lang/p4runtime/go/p4/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"time"
+
+	p4_v1 "github.com/p4lang/p4runtime/go/p4/v1"
 )
 
 var (

--- a/test/integration/verify_bess.go
+++ b/test/integration/verify_bess.go
@@ -4,14 +4,15 @@
 package integration
 
 import (
+	"testing"
+
 	"github.com/omec-project/upf-epc/pkg/fake_bess"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 // TODO: current assertions are limited to quantity verification only. We'd like to extend this
-//       and check entry contents as well.
-func verifyBessEntries(t *testing.T, bess *fake_bess.FakeBESS, testdata *pfcpSessionData, expectedValues p4RtValues, ueState UEState) {
+// and check entry contents as well.
+func verifyBessEntries(t *testing.T, bess *fake_bess.FakeBESS, expectedValues p4RtValues) {
 	// Check we have all expected PDRs.
 	pdrs := bess.GetPdrTableEntries()
 	require.Equal(t, len(expectedValues.pdrs), len(pdrs), "found unexpected PDR entries %v", pdrs)

--- a/test/integration/verify_up4.go
+++ b/test/integration/verify_up4.go
@@ -5,6 +5,9 @@ package integration
 
 import (
 	"fmt"
+	"math"
+	"testing"
+
 	p4rtc "github.com/antoninbas/p4runtime-go-client/pkg/client"
 	"github.com/antoninbas/p4runtime-go-client/pkg/util/conversion"
 	"github.com/omec-project/upf-epc/internal/p4constants"
@@ -12,8 +15,6 @@ import (
 	"github.com/omec-project/upf-epc/test/integration/providers"
 	p4_v1 "github.com/p4lang/p4runtime/go/p4/v1"
 	"github.com/stretchr/testify/require"
-	"math"
-	"testing"
 )
 
 const (
@@ -465,7 +466,7 @@ func verifyNumberOfEntries(t *testing.T, tableID uint32, expectedNoOfEntries int
 	require.Len(t, entries, expectedNoOfEntries)
 }
 
-func verifyNoP4RuntimeEntries(t *testing.T, expectedValues p4RtValues) {
+func verifyNoP4RuntimeEntries(t *testing.T) {
 	p4rtClient, err := providers.ConnectP4rt("127.0.0.1:50001", false)
 	require.NoErrorf(t, err, "failed to connect to P4Runtime server")
 	defer providers.DisconnectP4rt()


### PR DESCRIPTION
Add go vet configuration to CI 
Enable go vet analyzers except for fieldalignment
Disable CI linters that fail
Fixes govet shadow, goimports, gofmt, unparam and inefassign linters
