### PR TITLE
Improve building process to reduce building time for BESS in the UPF 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,28 +5,24 @@
 # Stage bess-build: fetch BESS dependencies & pre-reqs
 FROM registry.aetherproject.org/sdcore/bess_build:latest AS bess-build
 ARG CPU=native
-ARG BESS_COMMIT=master
 ENV PLUGINS_DIR=plugins
 ARG MAKEFLAGS
 ENV PKG_CONFIG_PATH=/usr/lib64/pkgconfig
 
-RUN apt-get update && apt-get install -y \
-    --no-install-recommends \
-    git \
-    ca-certificates \
-    libbpf0 \
-    libelf-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# BESS pre-reqs
 WORKDIR /bess
-RUN git clone https://github.com/omec-project/bess.git . && \
-    git checkout ${BESS_COMMIT} && \
-    cp -a protobuf /protobuf
 
-# Build DPDK
-RUN ./build.py dpdk
+## Developers can uncomment the following lines to use their own BESS repo/changes
+# ARG BESS_COMMIT=<your-branch>
+# RUN cd .. && \
+#     rm -rf bess && \
+#     git clone https://github.com/<your-repo>/bess.git && \
+#     cd bess && \
+#     git checkout ${BESS_COMMIT} && \
+#     ./build.py dpdk
+## End comment out section
+
+# Copy protobuf files for use in later stages (below)
+RUN cp -a protobuf /protobuf
 
 # Plugins: SequentialUpdate
 RUN mkdir -p plugins && \


### PR DESCRIPTION
The objective of this PR is to reduce BESS' building time. Currently, the DPDK of BESS in built in BESS and then deleted and then it is built again here in the UPF. The changes here aim to reduce the redundancies of building DPDK multiple times.

The changes in the PR were tested deploying the UPF in standalone mode and deploying the UPF as part of OnRamp

Before: build time was ~17 mins, now the build time is reduced to ~7 mins
![image](https://github.com/omec-project/upf/assets/87488727/9953eff0-6b34-4d6f-b49d-c0e020fc02df)
![image](https://github.com/omec-project/upf/assets/87488727/6d7fce77-6689-4c75-9b24-ea3080d348be)
