### PR TITLE
Use all available cores

### DIFF
--- a/conf/up4.bess
+++ b/conf/up4.bess
@@ -7,6 +7,7 @@ from conf.parser import *
 from conf.gtp_echo import *
 import conf.ports as port
 import conf.sim as sim
+import os
 import signal
 
 port.setup_globals()
@@ -99,7 +100,7 @@ else:
 
 
 # Initialize workers
-cores = get_process_affinity()
+cores = list(range(os.cpu_count()))
 workers = cores[:parser.workers]
 if len(cores) > parser.workers:
     nonworkers = cores[parser.workers:]

--- a/conf/utils.py
+++ b/conf/utils.py
@@ -39,7 +39,7 @@ def getpythonpid(process_name):
 
 def get_json_conf(path, dump):
     try:
-        with open(path, 'r') as f:
+        with open(path, "r") as f:
             jsonc_data = f.read()
         jc = JsonComment()
         conf = jc.loads(jsonc_data)
@@ -126,10 +126,6 @@ def cidr2netmask(cidr):
 
 def ip2long(ip):
     return iptools.ipv4.ip2long(ip)
-
-
-def get_process_affinity():
-    return psutil.Process().cpu_affinity()
 
 
 def set_process_affinity(pid, cpus):


### PR DESCRIPTION
When determining what cores are available, we should use the total number from the system, not from the current process

Addresses #780 