### PR TITLE
Ignore invalid argument

### DIFF
--- a/conf/utils.py
+++ b/conf/utils.py
@@ -137,7 +137,9 @@ def set_process_affinity(pid, cpus):
         psutil.Process(pid).cpu_affinity(cpus)
     except OSError as e:
         # 22 = Invalid argument; PID has PF_NO_SETAFFINITY set
-        if e.errno != 22:
+        if e.errno == 22:
+            print(f"Failed to set affinity on process {pid} {psutil.Process(pid).name}")
+        else:
             raise e
 
 

--- a/conf/utils.py
+++ b/conf/utils.py
@@ -133,7 +133,12 @@ def get_process_affinity():
 
 
 def set_process_affinity(pid, cpus):
-    psutil.Process(pid).cpu_affinity(cpus)
+    try:
+        psutil.Process(pid).cpu_affinity(cpus)
+    except OSError as e:
+        # 22 = Invalid argument; PID has PF_NO_SETAFFINITY set
+        if e.errno != 22:
+            raise e
 
 
 def set_process_affinity_all(cpus):


### PR DESCRIPTION
If the process that we are trying to set affinity on has the PF_NO_SETAFFINITY bit set, the call to set affinity will result in OSError 22 being thrown.

Fixes #779 