### PR TITLE
fix: Use ndb and arrange the methods

### DIFF
--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -613,7 +613,7 @@ class RouteController:
             netlink_message (dict): The netlink message.
         """
         try:
-            event = netlink_message.get("event")
+            event = netlink_message.get('event')
         except Exception:
             logger.exception("Error parsing netlink message")
             return

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -811,7 +811,7 @@ def register_signal_handlers(controller: RouteController) -> None:
 if __name__ == "__main__":
     interface_arg, ip_arg, port_arg = parse_args()
     ipr = IPRoute()
-    ndb = NDB(log="debug")
+    ndb = NDB(rtnl_debug=True)
     bess_controller = BessController(ip_arg, port_arg)
     route_controller = RouteController(
         bess_controller=bess_controller,

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -634,10 +634,9 @@ class RouteController:
             _: target
             netlink_message (dict): The netlink message.
         """
-        try:
-            event = netlink_message.get('event')
-        except Exception:
-            logger.exception("Error parsing netlink message")
+        event = netlink_message.get('event')
+        if event is None:
+            logger.error("Netlink message does not include an event.")
             return
 
         logger.info("%s netlink event received.", event)
@@ -688,7 +687,7 @@ class RouteController:
         """
         try:
             attr_dict = dict(route_entry["attrs"])
-        except Exception:
+        except (ValueError, KeyError):
             logger.exception("Error parsing route entry message")
             return None
 

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -616,7 +616,7 @@ class RouteController:
             netlink_message (dict): The netlink message.
         """
         try:
-            event = netlink_message.get('event')
+            event = netlink_message.get("event")
         except Exception:
             logger.exception("Error parsing netlink message")
             return
@@ -634,7 +634,7 @@ class RouteController:
             _: target
             netlink_message (dict): The netlink message.
         """
-        event = netlink_message.get('event')
+        event = netlink_message.get("event")
         if event is None:
             logger.error("Netlink message does not include an event.")
             return

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -613,7 +613,7 @@ class RouteController:
             netlink_message (dict): The netlink message.
         """
         try:
-            event = netlink_message.get('event')
+            event = netlink_message.get("event")
         except Exception:
             logger.exception("Error parsing netlink message")
             return

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -606,10 +606,11 @@ class RouteController:
             return cached_entry.gate_idx
         return self._module_gate_count_cache[module_name]
 
-    def _netlink_event_listener(self, netlink_message: dict) -> None:
+    def _netlink_event_listener(self, _, netlink_message: dict) -> None:
         """Listens for netlink events and handles them.
 
         Args:
+            _ : target
             netlink_message (dict): The netlink message.
         """
         try:

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -345,13 +345,12 @@ class RouteController:
         self._ping_missing_thread = Thread(
             target=self._ping_missing_entries, daemon=True
         )
-        self._event_callback = None
         self._interfaces = interfaces
 
     def register_handlers(self) -> None:
         """Register handler function."""
         logger.info("Registering netlink event listener handler...")
-        self._event_callback = self._ndb.task_manager.register_handler(
+        self._ndb.task_manager.register_handler(
             ifinfmsg,
             self._netlink_event_listener,
         )
@@ -638,7 +637,10 @@ class RouteController:
     def cleanup(self, number: int) -> None:
         """Unregisters the netlink event listener callback and exits."""
         logger.info("Received: %i Exiting", number)
-        self._ndb.task_manager.unregister_callback(self._event_callback)
+        self._ndb.task_manager.unregister_handler(
+            ifinfmsg,
+            self._netlink_event_listener,
+        )
         logger.info("Unregistered netlink event listener callback")
         sys.exit()
 

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -347,7 +347,7 @@ class RouteController:
 
     def register_handlers(self) -> None:
         """Register handler functions."""
-        logger.info("Registering netlink event listener handler...")
+        logger.info("Registering netlink event listener handlers...")
         self._ndb.task_manager.register_handler(
             rtmsg,
             self._netlink_route_handler,
@@ -609,11 +609,11 @@ class RouteController:
             return cached_entry.gate_idx
         return self._module_gate_count_cache[module_name]
 
-    def _netlink_neighbor_handler(self, target, netlink_message: dict) -> None:
+    def _netlink_neighbor_handler(self, _, netlink_message: dict) -> None:
         """Listens for netlink neighbor events and handles them.
 
         Args:
-            target: target
+            _: target
             netlink_message (dict): The netlink message.
         """
         try:
@@ -628,11 +628,11 @@ class RouteController:
             with self._lock:
                 self.add_unresolved_new_neighbor(netlink_message)
 
-    def _netlink_route_handler(self, target, netlink_message: dict) -> None:
+    def _netlink_route_handler(self, _, netlink_message: dict) -> None:
         """Listens for netlink route events and handles them.
 
         Args:
-            target: target
+            _: target
             netlink_message (dict): The netlink message.
         """
         try:
@@ -652,7 +652,7 @@ class RouteController:
                 self.delete_route_entry(route_entry)
 
     def cleanup(self, number: int) -> None:
-        """Unregisters the netlink event listener callback and exits."""
+        """Unregisters the netlink event handlers and exits."""
         logger.info("Received: %i Exiting", number)
         self._ndb.task_manager.unregister_handler(
             rtmsg,

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -673,7 +673,7 @@ class RouteController:
             self._module_gate_count_cache.clear()
         self.bootstrap_routes()
         signal.pause()
-        logger.info("Received: %i Reconfigured", number)
+        logger.info("Received: %i reconfigured", number)
 
     def _parse_route_entry_msg(self, route_entry: dict) -> Optional[RouteEntry]:
         """Parses a route entry message.

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -608,15 +608,17 @@ class RouteController:
             return cached_entry.gate_idx
         return self._module_gate_count_cache[module_name]
 
-    def _netlink_event_listener(self, _, netlink_message: dict) -> None:
+    def _netlink_event_listener(self, target, netlink_message: dict) -> None:
         """Listens for netlink events and handles them.
 
         Args:
-            _ : target
+            target: target
             netlink_message (dict): The netlink message.
         """
         try:
+            logger.info("target:", target)
             event = netlink_message.get('event')
+            logger.info("event: %s is received.", event)
         except Exception:
             logger.exception("Error parsing netlink message")
             return

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -616,9 +616,7 @@ class RouteController:
             netlink_message (dict): The netlink message.
         """
         try:
-            logger.info("target: %s", target)
             event = netlink_message.get('event')
-            logger.info("event: %s is received.", event)
         except Exception:
             logger.exception("Error parsing netlink message")
             return

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -14,8 +14,9 @@ from dataclasses import dataclass, field
 from threading import Lock, Thread
 from typing import Dict, List, Optional, Tuple
 
+from pr2modules.netlink.rtnl.ifinfmsg import ifinfmsg
 from pybess.bess import *
-from pyroute2 import IPDB, IPRoute
+from pyroute2 import NDB, IPRoute
 from scapy.all import ICMP, IP, send
 
 LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
@@ -188,9 +189,9 @@ class BessController:
         """Creates a BESS module.
 
         Args:
-            gateway_mac (int): MAC address of the gateway as an int.
-            update_module_name (str): The name of the module.
+            module_name (str): The name of the module.
             module_class (str): The class of the module.
+            gateway_mac (int): MAC address of the gateway as an int.
         """
         for _ in range(self.MAX_RETRIES):
             try:
@@ -275,7 +276,7 @@ class BessController:
         """Deletes a BESS module.
 
         Args:
-            update_module (str): The name of the module to delete.
+            module_name (str): The name of the module to delete.
         """
         for _ in range(self.MAX_RETRIES):
             try:
@@ -308,7 +309,7 @@ class RouteController:
     def __init__(
         self,
         bess_controller: BessController,
-        ipdb: IPDB,
+        ndb: NDB,
         ipr: IPRoute,
         interfaces: List[str],
     ):
@@ -318,9 +319,9 @@ class RouteController:
         Args:
             bess_controller (BessController):
                 Controller for BESS (Berkeley Extensible Software Switch).
-            route_parser (RouteEntryParser): Parser for route entries.
-            ipdb (IPDB): IP database to manage IP configurations.
+            ndb (NDB): database to manage Network configurations.
             ipr (IPRoute): IP routing control object.
+            interfaces: list of interfaces
 
         Attributes:
             _unresolved_arp_queries_cache (dict[str, RouteEntry]):
@@ -336,7 +337,7 @@ class RouteController:
 
         self._lock = Lock()
 
-        self._ipdb = ipdb
+        self._ndb = ndb
         self._ipr = ipr
         self._bess_controller = bess_controller
         self._ping_missing_thread = Thread(
@@ -345,11 +346,12 @@ class RouteController:
         self._event_callback = None
         self._interfaces = interfaces
 
-    def register_callbacks(self) -> None:
-        """Register callback function."""
-        logger.info("Registering netlink event listener callback...")
-        self._event_callback = self._ipdb.register_callback(
-            self._netlink_event_listener
+    def register_handlers(self) -> None:
+        """Register handler function."""
+        logger.info("Registering netlink event listener handler...")
+        self._event_callback = self._ndb.task_manager.register_handler(
+            ifinfmsg,
+            self._netlink_event_listener,
         )
 
     def start_pinging_missing_entries(self) -> None:
@@ -359,7 +361,7 @@ class RouteController:
             logger.info("Ping missing entries thread started")
 
     def bootstrap_routes(self) -> None:
-        """Goes through all routes and handles new ones.."""
+        """Goes through all routes and handles new ones."""
         routes = self._ipr.get_routes()
         for route in routes:
             if route["event"] == KEY_NEW_ROUTE_ACTION:
@@ -373,7 +375,7 @@ class RouteController:
         Args:
             route_entry (RouteEntry): The route entry.
         """
-        if not (next_hop_mac := fetch_mac(self._ipdb, route_entry.next_hop_ip)):
+        if not (next_hop_mac := fetch_mac(self._ndb, route_entry.next_hop_ip)):
             logger.info(
                 "mac address of the next hop %s is not stored in ARP table. Probing...",
                 route_entry.next_hop_ip,
@@ -385,6 +387,7 @@ class RouteController:
 
     def _add_neighbor(self, route_entry: RouteEntry, next_hop_mac: str) -> None:
         """Adds the route in BESS module.
+
         Creates required BESS modules.
 
         Args:
@@ -554,6 +557,7 @@ class RouteController:
 
     def _ping_missing_entries(self):
         """Pings missing entries every 10 seconds.
+
         The goal is to populate the ARP cache.
         If the target host does not respond it will be pinged again.
         """
@@ -574,7 +578,7 @@ class RouteController:
         Pings the neighbor to trigger the update of the ARP table.
 
         Args:
-            neighbor (NeighborEntry): The neighbor entry.
+            route_entry (NeighborEntry): The neighbor entry.
         """
 
         self._unresolved_arp_queries_cache[route_entry.next_hop_ip] = route_entry
@@ -602,34 +606,36 @@ class RouteController:
             return cached_entry.gate_idx
         return self._module_gate_count_cache[module_name]
 
-    def _netlink_event_listener(
-        self, ipdb: IPDB, netlink_message: dict, action: str
-    ) -> None:
+    def _netlink_event_listener(self, netlink_message: dict) -> None:
         """Listens for netlink events and handles them.
 
         Args:
-            ipdb (IPDB): The IPDB object.
             netlink_message (dict): The netlink message.
-            action (str): The action.
         """
-        logger.info("%s netlink event received.", action)
+        try:
+            event = netlink_message.get('event')
+        except Exception:
+            logger.exception("Error parsing netlink message")
+            return
+
+        logger.info("%s netlink event received.", event)
         route_entry = self._parse_route_entry_msg(netlink_message)
-        if action == KEY_NEW_ROUTE_ACTION and route_entry:
+        if event == KEY_NEW_ROUTE_ACTION and route_entry:
             with self._lock:
                 self.add_new_route_entry(route_entry)
 
-        elif action == KEY_DELETE_ROUTE_ACTION and route_entry:
+        elif event == KEY_DELETE_ROUTE_ACTION and route_entry:
             with self._lock:
                 self.delete_route_entry(route_entry)
 
-        elif action == KEY_NEW_NEIGHBOR_ACTION:
+        elif event == KEY_NEW_NEIGHBOR_ACTION:
             with self._lock:
                 self.add_unresolved_new_neighbor(netlink_message)
 
     def cleanup(self, number: int) -> None:
         """Unregisters the netlink event listener callback and exits."""
         logger.info("Received: %i Exiting", number)
-        self._ipdb.unregister_callback(self._event_callback)
+        self._ndb.task_manager.unregister_callback(self._event_callback)
         logger.info("Unregistered netlink event listener callback")
         sys.exit()
 
@@ -667,7 +673,7 @@ class RouteController:
         if not attr_dict.get(KEY_INTERFACE):
             return None
         interface_index = int(attr_dict.get(KEY_INTERFACE))
-        interface = self._ipdb.interfaces[interface_index].ifname
+        interface = self._ndb.interfaces[interface_index].get("ifname")
         if interface not in self._interfaces:
             return None
 
@@ -688,7 +694,8 @@ class RouteController:
             prefix_len=route_entry[KEY_DESTINATION_PREFIX_LENGTH],
         )
 
-    def get_route_module_name(self, interface_name: str) -> str:
+    @staticmethod
+    def get_route_module_name(interface_name: str) -> str:
         """Returns the name of the route module.
 
         Args:
@@ -696,16 +703,18 @@ class RouteController:
         """
         return interface_name + "Routes"
 
-    def get_update_module_name(self, route_module_name: str, mac_address: str) -> str:
+    @staticmethod
+    def get_update_module_name(route_module_name: str, mac_address: str) -> str:
         """Returns the name of the update module.
 
         Args:
             route_module_name (str): The name of the route module.
-            gateway_mac_hex (str): The MAC address of the gateway.
+            mac_address (str): The MAC address of the gateway.
         """
         return route_module_name + "DstMAC" + mac_to_hex(mac_address)
 
-    def get_merge_module_name(self, interface_name: str) -> str:
+    @staticmethod
+    def get_merge_module_name(interface_name: str) -> str:
         """Returns the name of the merge module.
 
         Args:
@@ -736,26 +745,25 @@ def send_ping(neighbor_ip):
     send(IP(dst=neighbor_ip) / ICMP())
 
 
-def fetch_mac(ipdb: IPDB, target_ip: str) -> Optional[str]:
-    """Fetches the MAC address of the target IP from the ARP table using IPDB.
+def fetch_mac(ndb: NDB, target_ip: str) -> Optional[str]:
+    """Fetches the MAC address of the target IP from the ARP table using NDB.
 
     Args:
-        ipdb (IPDB): The IPDB object.
+        ndb (NDB): The NDB object.
         target_ip (str): The target IP address.
 
     Returns:
         Optional[str]: The MAC address of the target IP.
     """
-    neighbors = ipdb.nl.get_neighbours(dst=target_ip)
+    neighbors = ndb.neighbours.dump()
     for neighbor in neighbors:
-        attrs = dict(neighbor["attrs"])
-        if attrs.get(KEY_NETWORK_LAYER_DEST_ADDR, "") == target_ip:
+        if neighbor["dst"] == target_ip:
             logger.info(
                 "Mac address found for %s, Mac: %s",
                 target_ip,
-                attrs.get(KEY_LINK_LAYER_ADDRESS, ""),
+                neighbor["lladdr"],
             )
-            return attrs.get(KEY_LINK_LAYER_ADDRESS, "")
+            return neighbor["lladdr"]
     logger.info("Mac address not found for %s", target_ip)
     return None
 
@@ -782,35 +790,35 @@ def parse_args() -> Tuple[List[str], str, str]:
     if not args.i:
         parser.print_help()
         raise ValueError("interface must be specified")
-    return (args.i, args.ip, args.port)
+    return args.i, args.ip, args.port
 
 
-def register_signal_handlers(route_controller: RouteController) -> None:
+def register_signal_handlers(controller: RouteController) -> None:
     """Register signal handlers for SIGHUP, SIGINT, SIGTERM.
 
     Args:
         controller (RouteController): The route controller.
     """
     logger.info("Registering signals handlers.")
-    signal.signal(signal.SIGHUP, lambda number, _: route_controller.reconfigure(number))
-    signal.signal(signal.SIGINT, lambda number, _: route_controller.cleanup(number))
-    signal.signal(signal.SIGTERM, lambda number, _: route_controller.cleanup(number))
+    signal.signal(signal.SIGHUP, lambda number, _: controller.reconfigure(number))
+    signal.signal(signal.SIGINT, lambda number, _: controller.cleanup(number))
+    signal.signal(signal.SIGTERM, lambda number, _: controller.cleanup(number))
 
 
 if __name__ == "__main__":
     interface_arg, ip_arg, port_arg = parse_args()
     ipr = IPRoute()
-    ipdb = IPDB()
+    ndb = NDB()
     bess_controller = BessController(ip_arg, port_arg)
     route_controller = RouteController(
         bess_controller=bess_controller,
-        ipdb=ipdb,
+        ndb=ndb,
         ipr=ipr,
         interfaces=interface_arg,
     )
     route_controller.bootstrap_routes()
-    route_controller.register_callbacks()
+    route_controller.register_handlers()
     route_controller.start_pinging_missing_entries()
-    register_signal_handlers(route_controller=route_controller)
+    register_signal_handlers(controller=route_controller)
     logger.info("Sleep until a signal is received")
     signal.pause()

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -832,7 +832,7 @@ def register_signal_handlers(controller: RouteController) -> None:
 if __name__ == "__main__":
     interface_arg, ip_arg, port_arg = parse_args()
     ipr = IPRoute()
-    ndb = NDB(rtnl_debug=True)
+    ndb = NDB()
     bess_controller = BessController(ip_arg, port_arg)
     route_controller = RouteController(
         bess_controller=bess_controller,

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -616,7 +616,7 @@ class RouteController:
             netlink_message (dict): The netlink message.
         """
         try:
-            logger.info("target:", target)
+            logger.info("target: %s", target)
             event = netlink_message.get('event')
             logger.info("event: %s is received.", event)
         except Exception:

--- a/conf/test_route_control.py
+++ b/conf/test_route_control.py
@@ -6,11 +6,9 @@ import sys
 import unittest
 from unittest.mock import MagicMock, Mock, patch
 
-from pyroute2 import IPDB  # type: ignore[import]
-
 sys.modules["pybess.bess"] = MagicMock()
 
-from conf.route_control import (NeighborEntry, RouteController, RouteEntry,
+from conf.route_control import (RouteController, RouteEntry,
                                 fetch_mac, mac_to_hex, mac_to_int,
                                 validate_ipv4)
 
@@ -50,7 +48,7 @@ class TestUtilityFunctions(unittest.TestCase):
     def test_given_invalid_ip_when_validate_ipv4_then_returns_false(self):
         self.assertFalse(validate_ipv4("192.168.300.1"))
 
-    def test_given_invalid_ip_when_validate_ipv4_then_returns_false(self):
+    def test_given_invalid_ip_when_validate_ipv6_then_returns_false(self):
         self.assertFalse(validate_ipv4("::1"))
         self.assertFalse(validate_ipv4(""))
 
@@ -67,27 +65,35 @@ class TestUtilityFunctions(unittest.TestCase):
         self.assertEqual(mac_to_hex("00:1a:2b:3c:4d:5e"), "001A2B3C4D5E")
 
     def test_given_known_destination_when_fetch_mac_then_returns_mac(self):
-        ipdb = IPDB()
-        ipdb.nl.get_neighbours = lambda dst, **kwargs: [
-            {"attrs": [("NDA_DST", dst), ("NDA_LLADDR", "00:1a:2b:3c:4d:5e")]}
-        ]
-        self.assertEqual(fetch_mac(ipdb, "192.168.1.1"), "00:1a:2b:3c:4d:5e")
+        ndb = Mock()
+        kwargs = {
+            "ifindex": 1,
+            "dst": "192.168.1.1",
+            "lladdr": "00:1a:2b:3c:4d:5e"
+        }
+        ndb.neighbours.dump.return_value = [kwargs]
+        self.assertEqual(fetch_mac(ndb, "192.168.1.1"), "00:1a:2b:3c:4d:5e")
 
-    def test_given_unkonw_destination_when_fetch_mac_then_returns_none(self):
-        ipdb = IPDB()
-        ipdb.nl.get_neighbours = lambda dst, **kwargs: []
-        self.assertIsNone(fetch_mac(ipdb, "192.168.1.1"))
+    def test_given_unknown_destination_when_fetch_mac_then_returns_none(self):
+        ndb = Mock()
+        kwargs = {
+            "ifindex": 1,
+            "dst": "192.168.1.1",
+            "lladdr": None
+        }
+        ndb.neighbours.dump.return_value = [kwargs]
+        self.assertIsNone(fetch_mac(ndb, "192.168.1.1"))
 
 
 class TestRouteController(unittest.TestCase):
     def setUp(self):
         self.mock_bess_controller = Mock(BessControllerMock)
-        self.ipdb = Mock()
+        self.ndb = Mock()
         self.ipr = Mock()
         interfaces = ["access", "core"]
         self.route_controller = RouteController(
             self.mock_bess_controller,
-            self.ipdb,
+            self.ndb,
             interfaces=interfaces,
             ipr=self.ipr,
         )
@@ -105,9 +111,12 @@ class TestRouteController(unittest.TestCase):
         mock_fetch_mac,
     ) -> None:
         """Adds a new route entry using the route controller."""
-        self.ipdb.nl.get_neighbours = lambda dst, **kwargs: [
-            {"attrs": [("NDA_DST", dst), ("NDA_LLADDR", "00:1a:2b:3c:4d:5e")]}
-        ]
+        kwargs = {
+            "ifindex": 1,
+            "dst": "192.168.1.1",
+            "lladdr": "00:1a:2b:3c:4d:5e"
+        }
+        self.ndb.neighbours.dump.return_value = [kwargs]
         mock_get_update_module_name.return_value = "merge_module"
         mock_get_route_module_name.return_value = "route_module"
         mock_get_merge_module_name.return_value = "update_module"
@@ -116,7 +125,7 @@ class TestRouteController(unittest.TestCase):
         return route_entry
 
     def test_given_valid_route_message_when_parse_message_then_parses_message(self):
-        self.ipdb.interfaces = {2: Mock(ifname="core")}
+        self.ndb.interfaces = {2: {"ifname": "core"}}
         example_route_entry = {
             "family": 2,
             "dst_len": 24,
@@ -141,13 +150,13 @@ class TestRouteController(unittest.TestCase):
         self.assertIsInstance(result, RouteEntry)
         self.assertEqual(result.dest_prefix, "192.168.1.0")
         self.assertEqual(result.next_hop_ip, "172.31.48.1")
-        self.assertEqual(result.interface, self.ipdb.interfaces[2].ifname)
+        self.assertEqual(result.interface, self.ndb.interfaces[2].get("ifname"))
         self.assertEqual(result.prefix_len, 24)
 
     def test_given_valid_route_message_and_dst_len_is_zero_when_parse_message_then_parses_message_as_default_route(
         self,
     ):
-        self.ipdb.interfaces = {2: Mock(ifname="core")}
+        self.ndb.interfaces = {2: {"ifname": "core"}}
         example_route_entry = {
             "family": 2,
             "dst_len": 0,
@@ -171,11 +180,11 @@ class TestRouteController(unittest.TestCase):
         self.assertIsInstance(result, RouteEntry)
         self.assertEqual(result.dest_prefix, "0.0.0.0")
         self.assertEqual(result.next_hop_ip, "172.31.48.1")
-        self.assertEqual(result.interface, self.ipdb.interfaces[2].ifname)
+        self.assertEqual(result.interface, self.ndb.interfaces[2].get("ifname"))
         self.assertEqual(result.prefix_len, 0)
 
     def test_given_invalid_route_message_when_parse_message_then_returns_none(self):
-        self.ipdb.interfaces = {2: Mock(ifname="not the needed interface")}
+        self.ndb.interfaces = {2: {"ifname": "not the needed interface"}}
         example_route_entry = {
             "family": 2,
             "flags": 0,
@@ -202,7 +211,12 @@ class TestRouteController(unittest.TestCase):
         self,
         mock_send_ping,
     ):
-        self.ipdb.nl.get_neighbours = lambda dst, **kwargs: []
+        kwargs = {
+            "ifindex": 1,
+            "dst": "192.168.1.1",
+            "lladdr": None
+        }
+        self.ndb.neighbours.dump.return_value = [kwargs]
         route_entry = RouteEntry(
             next_hop_ip="1.2.3.4",
             interface="random_interface",
@@ -212,12 +226,16 @@ class TestRouteController(unittest.TestCase):
         self.route_controller.add_new_route_entry(route_entry)
         mock_send_ping.assert_called_once()
 
+    @patch("conf.route_control.send_ping")
     def test_given_valid_new_route_when_add_new_route_entry_and_mac_known_then_route_is_added_in_bess(
-        self,
+        self, _
     ):
-        self.ipdb.nl.get_neighbours = lambda dst, **kwargs: [
-            {"attrs": [("NDA_DST", dst), ("NDA_LLADDR", "00:1a:2b:3c:4d:5e")]}
-        ]
+        kwargs = {
+            "ifindex": 1,
+            "dst": "192.168.1.1",
+            "lladdr": "00:1a:2b:3c:4d:5e"
+        }
+        self.ndb.neighbours.dump.return_value = [kwargs]
         mock_routes = [{"event": "RTM_NEWROUTE"}, {"event": "OTHER_ACTION"}]
         self.ipr.get_routes.return_value = mock_routes
         route_entry = RouteEntry(
@@ -227,14 +245,19 @@ class TestRouteController(unittest.TestCase):
             prefix_len=24,
         )
         self.route_controller.add_new_route_entry(route_entry)
+        self.mock_bess_controller.add_route_to_module()
         self.mock_bess_controller.add_route_to_module.assert_called_once()
 
-    def test_given_valid_new_route_when_add_new_route_entry_and_mac_known_and_neighbor_not_known_then_update_module_is_created_and_modules_are_linked(
-        self,
+    @patch("conf.route_control.send_ping")
+    def test_given_valid_new_route_when_add_new_route_entry_and_mac_known_and_neighbor_not_known_then_update_module_is_created_and_modules_are_linked(  # noqa: E501
+        self, _
     ):
-        self.ipdb.nl.get_neighbours = lambda dst, **kwargs: [
-            {"attrs": [("NDA_DST", dst), ("NDA_LLADDR", "00:1a:2b:3c:4d:5e")]}
-        ]
+        kwargs = {
+            "ifindex": 1,
+            "dst": "1.2.3.4",
+            "lladdr": "00:1a:2b:3c:4d:5e"
+        }
+        self.ndb.neighbours.dump.return_value = [kwargs]
         mock_routes = [{"event": "RTM_NEWROUTE"}, {"event": "OTHER_ACTION"}]
         self.ipr.get_routes.return_value = mock_routes
         route_entry = RouteEntry(
@@ -265,7 +288,7 @@ class TestRouteController(unittest.TestCase):
             {"event": "OTHER_ACTION"},
         ]
         self.ipr.get_routes.return_value = mock_routes
-        self.ipdb.interfaces = {2: Mock(ifname="core")}
+        self.ndb.interfaces = {2: {"ifname": "core"}}
         valid_route_entry = RouteEntry(
             next_hop_ip="1.2.3.4",
             interface="core",
@@ -322,7 +345,7 @@ class TestRouteController(unittest.TestCase):
     def test_given_netlink_message_when_rtm_newroute_event_then_add_new_route_entry_is_called(
         self, mock_add_new_route_entry
     ):
-        self.ipdb.interfaces = {2: Mock(ifname="core")}
+        self.ndb.interfaces = {2: {"ifname": "core"}}
         example_route_entry = {
             "family": 2,
             "dst_len": 24,
@@ -344,7 +367,7 @@ class TestRouteController(unittest.TestCase):
             "event": "RTM_NEWROUTE",
         }
         self.route_controller._netlink_event_listener(
-            self.ipdb, example_route_entry, "RTM_NEWROUTE"
+            example_route_entry
         )
         mock_add_new_route_entry.assert_called()
 
@@ -398,7 +421,7 @@ class TestRouteController(unittest.TestCase):
     def test_given_netlink_message_when_rtm_delroute_event_then_delete_route_entry_is_called(
         self, mock_delete_route_entry
     ):
-        self.ipdb.interfaces = {2: Mock(ifname="core")}
+        self.ndb.interfaces = {2: {"ifname": "core"}}
         example_route_entry = {
             "family": 2,
             "dst_len": 24,
@@ -420,7 +443,7 @@ class TestRouteController(unittest.TestCase):
             "event": "RTM_DELROUTE",
         }
         self.route_controller._netlink_event_listener(
-            self.ipdb, example_route_entry, "RTM_DELROUTE"
+            example_route_entry
         )
         mock_delete_route_entry.assert_called()
 
@@ -429,9 +452,12 @@ class TestRouteController(unittest.TestCase):
         self,
         _,
     ):
-        self.ipdb.nl.get_neighbours = lambda dst, **kwargs: [
-            {"attrs": [("NDA_DST", dst), ("NDA_LLADDR", "00:1a:2b:3c:4d:5e")]}
-        ]
+        kwargs = {
+            "ifindex": 1,
+            "dst": "192.168.1.1",
+            "lladdr": "00:1a:2b:3c:4d:5e"
+        }
+        self.ndb.neighbours.dump.return_value = [kwargs]
         mock_netlink_msg = {
             "attrs": {
                 "NDA_DST": "1.2.3.4",
@@ -455,6 +481,6 @@ class TestRouteController(unittest.TestCase):
         self, mock_add_unresolved_new_neighbor
     ):
         self.route_controller._netlink_event_listener(
-            self.ipdb, "new neighbour message", "RTM_NEWNEIGH"
+            {"event": "RTM_NEWNEIGH"}
         )
         mock_add_unresolved_new_neighbor.assert_called()

--- a/conf/test_route_control.py
+++ b/conf/test_route_control.py
@@ -367,6 +367,7 @@ class TestRouteController(unittest.TestCase):
             "event": "RTM_NEWROUTE",
         }
         self.route_controller._netlink_event_listener(
+            self.ndb,
             example_route_entry
         )
         mock_add_new_route_entry.assert_called()
@@ -443,6 +444,7 @@ class TestRouteController(unittest.TestCase):
             "event": "RTM_DELROUTE",
         }
         self.route_controller._netlink_event_listener(
+            self.ndb,
             example_route_entry
         )
         mock_delete_route_entry.assert_called()
@@ -481,6 +483,7 @@ class TestRouteController(unittest.TestCase):
         self, mock_add_unresolved_new_neighbor
     ):
         self.route_controller._netlink_event_listener(
+            self.ndb,
             {"event": "RTM_NEWNEIGH"}
         )
         mock_add_unresolved_new_neighbor.assert_called()

--- a/conf/test_route_control.py
+++ b/conf/test_route_control.py
@@ -99,9 +99,9 @@ class TestRouteController(unittest.TestCase):
         )
 
     @patch("conf.route_control.fetch_mac")
-    @patch.object(RouteController, "get_merge_module_name")
-    @patch.object(RouteController, "get_route_module_name")
-    @patch.object(RouteController, "get_update_module_name")
+    @patch("conf.route_control.get_merge_module_name")
+    @patch("conf.route_control.get_route_module_name")
+    @patch("conf.route_control.get_update_module_name")
     def add_route_entry(
         self,
         route_entry,
@@ -487,3 +487,5 @@ class TestRouteController(unittest.TestCase):
             {"event": "RTM_NEWNEIGH"}
         )
         mock_add_unresolved_new_neighbor.assert_called()
+
+

--- a/conf/test_route_control.py
+++ b/conf/test_route_control.py
@@ -487,5 +487,3 @@ class TestRouteController(unittest.TestCase):
             {"event": "RTM_NEWNEIGH"}
         )
         mock_add_unresolved_new_neighbor.assert_called()
-
-

--- a/conf/test_route_control.py
+++ b/conf/test_route_control.py
@@ -366,7 +366,7 @@ class TestRouteController(unittest.TestCase):
             },
             "event": "RTM_NEWROUTE",
         }
-        self.route_controller._netlink_event_listener(
+        self.route_controller._netlink_route_handler(
             self.ndb,
             example_route_entry
         )
@@ -443,7 +443,7 @@ class TestRouteController(unittest.TestCase):
             },
             "event": "RTM_DELROUTE",
         }
-        self.route_controller._netlink_event_listener(
+        self.route_controller._netlink_route_handler(
             self.ndb,
             example_route_entry
         )
@@ -482,7 +482,7 @@ class TestRouteController(unittest.TestCase):
     def test_given_netlink_message_when_rtm_newneigh_event_then_add_unresolved_new_neighbor_is_called(
         self, mock_add_unresolved_new_neighbor
     ):
-        self.route_controller._netlink_event_listener(
+        self.route_controller._netlink_neighbor_handler(
             self.ndb,
             {"event": "RTM_NEWNEIGH"}
         )

--- a/conf/utils.py
+++ b/conf/utils.py
@@ -79,16 +79,12 @@ def atoh(ip):
 
 def alias_by_interface(name) -> Optional[str]:
     ndb = NDB()
-    interfaces = ndb.interfaces
-    if iface_record := interfaces.get(name):
-        return iface_record["ifalias"]
+    return ndb.interfaces[name]["ifalias"]
 
 
 def mac_by_interface(name) -> Optional[str]:
     ndb = NDB()
-    interfaces = ndb.interfaces
-    if iface_record := interfaces.get(name):
-        return iface_record["address"]
+    return ndb.interfaces[name]["address"]
 
 
 def mac2hex(mac):

--- a/conf/utils.py
+++ b/conf/utils.py
@@ -63,7 +63,7 @@ def get_env(varname, default=None):
             exit(1, "Empty env var {}".format(varname))
 
 
-def ips_by_interface(name) -> list:
+def ips_by_interface(name: str) -> list[str]:
     ndb = NDB()
     interfaces = ndb.interfaces
     if iface_record := interfaces.get(name):
@@ -77,13 +77,13 @@ def atoh(ip):
     return socket.inet_aton(ip)
 
 
-def alias_by_interface(name) -> Optional[str]:
+def alias_by_interface(name: str) -> Optional[str]:
     ndb = NDB()
     if iface_record := ndb.interfaces.get(name):
         return iface_record["ifalias"]
 
 
-def mac_by_interface(name) -> Optional[str]:
+def mac_by_interface(name: str) -> Optional[str]:
     ndb = NDB()
     if iface_record := ndb.interfaces.get(name):
         return iface_record["address"]
@@ -93,7 +93,7 @@ def mac2hex(mac):
     return int(mac.replace(":", ""), 16)
 
 
-def peer_by_interface(name) -> str:
+def peer_by_interface(name: str) -> str:
     ndb = NDB()
     try:
         peer_idx = ndb.interfaces[name]["link"]

--- a/conf/utils.py
+++ b/conf/utils.py
@@ -79,12 +79,14 @@ def atoh(ip):
 
 def alias_by_interface(name) -> Optional[str]:
     ndb = NDB()
-    return ndb.interfaces[name]["ifalias"]
+    if iface_record := ndb.interfaces.get(name):
+        return iface_record["ifalias"]
 
 
 def mac_by_interface(name) -> Optional[str]:
     ndb = NDB()
-    return ndb.interfaces[name]["address"]
+    if iface_record := ndb.interfaces.get(name):
+        return iface_record["address"]
 
 
 def mac2hex(mac):

--- a/conf/utils.py
+++ b/conf/utils.py
@@ -2,16 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 Intel Corporation
 
-import json
 import os
 import socket
 import struct
 import sys
+from typing import Optional
 
 import iptools
 from jsoncomment import JsonComment
 import psutil
-from pyroute2 import IPDB
+from pyroute2 import NDB
+from socket import AF_INET
 
 
 def exit(code, msg):
@@ -62,34 +63,43 @@ def get_env(varname, default=None):
             exit(1, "Empty env var {}".format(varname))
 
 
-def ips_by_interface(name):
-    ipdb = IPDB()
-    return [ipobj[0] for ipobj in ipdb.interfaces[name]["ipaddr"].ipv4]
+def ips_by_interface(name) -> list:
+    ndb = NDB()
+    interfaces = ndb.interfaces
+    if iface_record := interfaces.get(name):
+        for address in iface_record.ipaddr:
+            if address["family"] == AF_INET:
+                return [address["local"]]
+    return []
 
 
 def atoh(ip):
     return socket.inet_aton(ip)
 
 
-def alias_by_interface(name):
-    ipdb = IPDB()
-    return ipdb.interfaces[name]["ifalias"]
+def alias_by_interface(name) -> Optional[str]:
+    ndb = NDB()
+    interfaces = ndb.interfaces
+    if iface_record := interfaces.get(name):
+        return iface_record["ifalias"]
 
 
-def mac_by_interface(name):
-    ipdb = IPDB()
-    return ipdb.interfaces[name]["address"]
+def mac_by_interface(name) -> Optional[str]:
+    ndb = NDB()
+    interfaces = ndb.interfaces
+    if iface_record := interfaces.get(name):
+        return iface_record["address"]
 
 
 def mac2hex(mac):
     return int(mac.replace(":", ""), 16)
 
 
-def peer_by_interface(name):
-    ipdb = IPDB()
+def peer_by_interface(name) -> str:
+    ndb = NDB()
     try:
-        peer_idx = ipdb.interfaces[name]["link"]
-        peer_name = ipdb.interfaces[peer_idx]["ifname"]
+        peer_idx = ndb.interfaces[name]["link"]
+        peer_name = ndb.interfaces[peer_idx]["ifname"]
     except:
         raise Exception("veth interface {} does not exist".format(name))
     else:


### PR DESCRIPTION
This PR tries to reach the aim of [draft PR](https://github.com/omec-project/upf/pull/758) by fixing some issues in the tests. 

IPDB is deprecated, and obsolete as stated in [IPDB module — pyroute2 0.7.3.post2 documentation](https://docs.pyroute2.org/ipdb_toc.html). This PR resolves https://github.com/omec-project/upf/issues/735 by replacing IPDB with NDB
