### PR TITLE
feat: return F-TEID in PFCP session establishment response

### DIFF
--- a/pfcpiface/messages_session.go
+++ b/pfcpiface/messages_session.go
@@ -165,7 +165,7 @@ func (pConn *PFCPConn) handleSessionEstablishmentRequest(msg message.Message) (m
 		localFSEID,
 	)
 
-	addPdrInfo(seres, &session)
+	addPdrInfo(seres, &session, pConn.upf.accessIP)
 
 	return seres, nil
 }

--- a/pfcpiface/session_pdr.go
+++ b/pfcpiface/session_pdr.go
@@ -29,9 +29,8 @@ func releaseAllocatedIPs(ippool *IPPool, session *PFCPSession) error {
 	return nil
 }
 
-func addPdrInfo(msg *message.SessionEstablishmentResponse,
-	session *PFCPSession) {
-	log.Println("Add PDRs with UPF alloc IPs to Establishment response")
+func addPdrInfo(msg *message.SessionEstablishmentResponse, session *PFCPSession, n3Address net.IP) {
+	log.Println("Add PDRs to Establishment response")
 
 	for _, pdr := range session.pdrs {
 		if (pdr.allocIPFlag) && (pdr.srcIface == core) {
@@ -42,12 +41,20 @@ func addPdrInfo(msg *message.SessionEstablishmentResponse,
 				ueIP  net.IP = int2ip(pdr.ueAddress)
 			)
 
-			log.Println("ueIP : ", ueIP.String())
-			msg.CreatedPDR = append(msg.CreatedPDR,
-				ie.NewCreatedPDR(
-					ie.NewPDRID(uint16(pdr.pdrID)),
-					ie.NewUEIPAddress(flags, ueIP.String(), "", 0, 0),
-				))
+			if ueIP != nil {
+				log.Println("ueIP : ", ueIP.String())
+				msg.CreatedPDR = append(msg.CreatedPDR,
+					ie.NewCreatedPDR(
+						ie.NewPDRID(uint16(pdr.pdrID)),
+						ie.NewUEIPAddress(flags, ueIP.String(), "", 0, 0),
+					))
+			} else {
+				msg.CreatedPDR = append(msg.CreatedPDR,
+					ie.NewCreatedPDR(
+						ie.NewPDRID(uint16(pdr.pdrID)),
+						ie.NewFTEID(0x01, pdr.tunnelTEID, n3Address, nil, 0),
+					))
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Description

According to the specification:
> If the PDR(s) is created successfully, the UP function shall return the F-TEID(s) it has assigned to the PDR(s) or to the
Traffic Endpoint(s) in the PFCP Session Establishment Response or PFCP Session Modification Response.

## This is still a draft

We may need to add logic for F-TEID allocation when not provided by the SMF.

## Reference
- [3GPP Release 16:  Interface between the Control Plane and the User Plane nodes](https://www.etsi.org/deliver/etsi_ts/129200_129299/129244/16.05.00_60/ts_129244v160500p.pdf)