### PR TITLE
Update route ctl logic to exclude IPV6 route entries

### DIFF
--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -18,6 +18,7 @@ from pyroute2.netlink.rtnl.ndmsg import ndmsg
 from pybess.bess import *
 from pyroute2 import NDB, IPRoute
 from scapy.all import ICMP, IP, send
+from socket import AF_INET
 
 LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
 logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
@@ -365,7 +366,7 @@ class RouteController:
 
     def bootstrap_routes(self) -> None:
         """Goes through all routes and handles new ones."""
-        routes = self._ipr.get_routes()
+        routes = self._ipr.get_routes(family=AF_INET)
         for route in routes:
             if route["event"] == KEY_NEW_ROUTE_ACTION:
                 if route_entry := self._parse_route_entry_msg(route):


### PR DESCRIPTION
In one of the deployment (CDAC-India Lab), it is observed that the IPV6 route entries also added to the UPF pipeline (accessRoutes/coreRoutes) which causes the traffic to be dropped at the wrong routing entries. This impacts the access to the internet, etc..,. In order to resolve this issue we added the logic to avoid IPV6 route entries during deployment of the UPF(routectl startup).