### PR TITLE
chore: enable predeclared linter in the CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - misspell
     - nilerr
     - nilnil
+    - predeclared
     - unconvert
     - unparam
     - unused
@@ -23,7 +24,6 @@ linters:
     - godox
     - nakedret
     - noctx
-    - predeclared
     - staticcheck
   settings:
     errcheck:

--- a/pfcpiface/datapath.go
+++ b/pfcpiface/datapath.go
@@ -44,9 +44,9 @@ type datapath interface {
 	SendEndMarkers(endMarkerList *[][]byte) error
 	/* write pdr/far/qer to datapath */
 	// "master" function to send create/update/delete messages to UPF.
-	// "new" PacketForwardingRules are only used for update messages to UPF.
+	// "newRules" PacketForwardingRules are only used for update messages to UPF.
 	// TODO: we should have better CRUD API, with a single function per message type.
-	SendMsgToUPF(method upfMsgType, all PacketForwardingRules, new PacketForwardingRules) uint8
+	SendMsgToUPF(method upfMsgType, all PacketForwardingRules, newRules PacketForwardingRules) uint8
 	/* check of communication channel to datapath is setup */
 	IsConnected(accessIP *net.IP) bool
 	SummaryLatencyJitter(uc *upfCollector, ch chan<- prometheus.Metric)


### PR DESCRIPTION
This PR does the modifications necessary to make the `predeclared` linter pass:
- Rename variable names that use go's reserved words: `any`, `clear`, `new`