### PR TITLE
chore: enable noctx linter in the CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - gomodguard
     - govet
     - misspell
+    - noctx
     - nilerr
     - nilnil
     - predeclared
@@ -23,7 +24,6 @@ linters:
     - errcheck
     - godox
     - nakedret
-    - noctx
     - staticcheck
   settings:
     errcheck:


### PR DESCRIPTION
### Description 

The `noctx` linter finds sending http request without context.Context.
Making a http call without context makes cancellation, timeout, or tracing impossible.

This PR adds context to the http post call.
