### PR TITLE
feat: update NAT and fastBPF modules when core ip changes

### DIFF
--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -410,7 +410,7 @@ class RouteController:
             logger.exception("Error handling IP address change")
 
     def _flush_arp_and_neighbor_cache(self):
-        """Flush neighbor and unresolved ARP caches and trigger refresh."""
+        """Flush neighbor and unresolved ARP caches"""
         with self._lock:
             self._unresolved_arp_queries_cache.clear()
             self._neighbor_cache.clear()
@@ -425,6 +425,7 @@ class RouteController:
             self._update_nat_module(new_ip)
             self._update_bpf_filter(new_ip)
             self._flush_arp_and_neighbor_cache()
+            self._bess_controller.run_module_command("coreRoutes", "clear", "EmptyArg", {})
 
             logger.info(f"Successfully updated core IP to {new_ip}")
 

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -381,7 +381,7 @@ class RouteController:
         """Handle IP address change events."""
         try:
             event = netlink_message.get("event")
-            if event not in {"RTM_NEWADDR", "RTM_DELADDR"}:
+            if event not in {"RTM_NEWADDR", "RTM_DELADDR", "RTM_DELROUTE", " RTM_ADDROUTE"}:
                 return
 
             if_idx = netlink_message.get("index")
@@ -395,13 +395,13 @@ class RouteController:
             if not interface or interface not in self._interfaces:
                 return
 
-            if event == "RTM_NEWADDR":
+            if event == "RTM_NEWADDR" or event == "RTM_ADDROUTE":
                 if ip_addr:
                     self._interface_ips[interface] = ip_addr
                     if interface == "core":
                         logger.info(f"Core IP address change detected: {ip_addr}")
                         self._update_core_ip(ip_addr)
-            elif event == "RTM_DELADDR":
+            elif event == "RTM_DELADDR" or event == "RTM_DELROUTE":
                 if ip_addr and self._interface_ips.get(interface) == ip_addr:
                     logger.info(f"Core IP address removed: {ip_addr}")
                     self._interface_ips.pop(interface, None)

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -6,7 +6,6 @@
 import argparse
 import ipaddress
 import logging
-import netifaces
 import signal
 import sys
 import time
@@ -369,12 +368,6 @@ class RouteController:
         )
         self._interfaces = interfaces
         self._interface_ips = {}
-        self.core_mac = self.get_core_interface_mac()
-
-    @staticmethod
-    def get_core_interface_mac():
-        core_mac = netifaces.ifaddresses("core")[netifaces.AF_LINK][0]["addr"]
-        return int(core_mac.replace(":", ""), 16)
 
     def register_handlers(self) -> None:
         """Register handler functions."""
@@ -438,22 +431,6 @@ class RouteController:
             self._bess_controller.pause_bess()
             self._update_bpf_filter(new_ip)
             self._flush_arp_and_neighbor_cache()
-            self._bess_controller.recreate_module_link(
-                upstream="coreRoutes",
-                ogate=0,
-                downstream="coreDstMAC2A0DE2304A5E",
-                igate=0,
-                klass="Update",
-                config={
-                    "fields": [
-                        {
-                            "offset": 0,
-                            "size": 6,
-                            "value": self.get_core_interface_mac()
-                        }
-                    ]
-                }
-            )
             self._bess_controller.recreate_module_link(
                 upstream="coreSrcEther",
                 ogate=0,

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -6,6 +6,7 @@
 import argparse
 import ipaddress
 import logging
+import netifaces
 import signal
 import sys
 import time
@@ -20,7 +21,6 @@ from pyroute2 import NDB, IPRoute
 from scapy.all import ICMP, IP, send
 from socket import AF_INET
 from pyroute2.netlink.rtnl.ifaddrmsg import ifaddrmsg
-import netifaces
 
 
 LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
@@ -317,14 +317,6 @@ class BessController:
         self.delete_module(downstream)
         self.create_module_with_config(downstream, klass, config)
         self.link_modules(upstream, downstream, ogate, igate)
-
-    def connect(self, m1: str, ogate: int, m2: str, igate: int):
-        """Connects two BESS modules."""
-        self._bess.connect_modules(m1, ogate, m2, igate)
-
-    def update_module_params(self, name: str, params: dict):
-        """Updates parameters of a BESS module using the 'command module' RPC."""
-        self._bess.run_module_command(name, "set_config", "Json", params)
 
     def create_module_with_config(self, module_name: str, module_class: str, config: dict) -> None:
         """Creates a generic BESS module with arbitrary config."""

--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -381,7 +381,7 @@ class RouteController:
         """Handle IP address change events."""
         try:
             event = netlink_message.get("event")
-            if event not in {"RTM_NEWADDR", "RTM_DELADDR", "RTM_DELROUTE", "RTM_ADDROUTE"}:
+            if event not in {"RTM_NEWADDR", "RTM_DELADDR"}:
                 return
 
             if_idx = netlink_message.get("index")
@@ -395,13 +395,13 @@ class RouteController:
             if not interface or interface not in self._interfaces:
                 return
 
-            if event == "RTM_NEWADDR" or event == "RTM_ADDROUTE":
+            if event == "RTM_NEWADDR":
                 if ip_addr:
                     self._interface_ips[interface] = ip_addr
                     if interface == "core":
                         logger.info(f"Core IP address change detected: {ip_addr}")
                         self._update_core_ip(ip_addr)
-            elif event == "RTM_DELADDR" or event == "RTM_DELROUTE":
+            elif event == "RTM_DELADDR":
                 if ip_addr and self._interface_ips.get(interface) == ip_addr:
                     logger.info(f"Core IP address removed: {ip_addr}")
                     self._interface_ips.pop(interface, None)
@@ -426,6 +426,15 @@ class RouteController:
             self._update_bpf_filter(new_ip)
             self._flush_arp_and_neighbor_cache()
             self._bess_controller.run_module_command("coreRoutes", "clear", "EmptyArg", {})
+            self._bess_controller.run_module_command(
+                "coreRoutes",
+                "add",
+                "RouteArg",
+                {
+                    "prefix": "0.0.0.0/0",
+                    "gate": 0
+                }
+            )
 
             logger.info(f"Successfully updated core IP to {new_ip}")
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/omec-project/pfcpsim v1.2.2
 	github.com/p4lang/p4runtime v1.3.0
 	github.com/prometheus/client_golang v1.11.1
+	github.com/prometheus/common v0.26.0
 	github.com/stretchr/testify v1.10.0
 	github.com/wmnsk/go-pfcp v0.0.24
 	go.uber.org/zap v1.27.0
@@ -26,6 +27,8 @@ require (
 
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
@@ -45,7 +48,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
-	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
@@ -59,6 +61,7 @@ require (
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,9 +8,11 @@ github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v
 github.com/Showmax/go-fqdn v1.0.0 h1:0rG5IbmVliNT5O19Mfuvna9LL7zlHyRfsSvBPZmF9tM=
 github.com/Showmax/go-fqdn v1.0.0/go.mod h1:SfrFBzmDCtCGrnHhoDjuvFnKsWjEQX/Q9ARZvOrJAko=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antoninbas/p4runtime-go-client v0.0.0-20220204221603-49eba9f248c1 h1:K/xygi8gBo3tFCs2577fIYuEZMtPDebQQz5T7f5teqE=
 github.com/antoninbas/p4runtime-go-client v0.0.0-20220204221603-49eba9f248c1/go.mod h1:NzHBH6Ig6nPZ/yd7HG/d+2J2r9afJYdLzi1VBekDJPo=
@@ -319,6 +321,7 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
 google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ grpcio
 iptools
 jsoncomment
 mitogen
+netifaces
 protobuf==3.20.3
 psutil
 pyroute2


### PR DESCRIPTION
To add DHCP capability to UPF NAT and FastBPF modules should be updated when UPF core ip address changes. This PR changes the route_control.py to handle module changes upon interface ip change by checking the netlink events.