### PR TITLE
feat: add E2E tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,3 +74,9 @@ jobs:
     uses: omec-project/.github/.github/workflows/fossa-scan.yml@main
     with:
       branch_name: ${{ github.ref }}
+
+  e2e-tests:
+    if: github.event_name == 'pull_request'
+    uses: omec-project/.github/.github/workflows/e2e-test.yml@main
+    with:
+      branch_name: ${{ github.ref }}


### PR DESCRIPTION
Run E2E tests for pull requests as part of CI process. Hence, we make sure that integrations tests will pass without manual testing.