### PR TITLE
Set `pyroute` to version 0.9.2 due to API changes in newer versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ jsoncomment
 mitogen
 protobuf==3.20.3
 psutil
-pyroute2
+pyroute2==0.9.2
 scapy


### PR DESCRIPTION
Fixes #931 