### PR TITLE
Fix issue #959: UPF crash on malformed Flow-Description in Session Establishment Request

### DIFF
--- a/pfcpiface/parse_sdf.go
+++ b/pfcpiface/parse_sdf.go
@@ -153,10 +153,6 @@ func parseFlowDesc(flowDesc, ueIP string) (*ipFilterRule, error) {
 			if i+1 < len(fields) && fields[i+1] != "to" {
 				i++
 
-				if i >= len(fields) {
-					return nil, errBadFilterDesc
-				}
-
 				err = ipf.src.parsePort(fields[i])
 				if err != nil {
 					parseLog.Errorln("src port parse failed", err)
@@ -176,7 +172,7 @@ func parseFlowDesc(flowDesc, ueIP string) (*ipFilterRule, error) {
 				return nil, err
 			}
 
-			if i < len(fields)-1 {
+			if i+1 < len(fields) {
 				i++
 
 				err = ipf.dst.parsePort(fields[i])


### PR DESCRIPTION
UPF crashes when processing malformed Flow-Description in Session Establishment Request.
UPF should handle such case gracefully.

The parseFlowDesc function used to access array elements without checking bounds
when processing malformed SDF filter flow descriptions, triggering a panic and
potential DoS vulnerability.

This change adds boundary checks in parseFlowDesc to prevent array out-of-bounds
access.

Fixes #959