### PR TITLE
Fix issue #962: UPF crash on malformed FAR (emptyIP) in Session Establishment Request

### DIFF
--- a/pfcpiface/utils.go
+++ b/pfcpiface/utils.go
@@ -65,10 +65,13 @@ func inc(ip net.IP) {
 }
 
 func ip2int(ip net.IP) uint32 {
+	// Guard against IP with insufficient length (need at least 4 bytes for uint32)
+	if len(ip) < 4 {
+		return 0
+	}
 	if len(ip) == 16 {
 		return binary.BigEndian.Uint32(ip[12:16])
 	}
-
 	return binary.BigEndian.Uint32(ip)
 }
 


### PR DESCRIPTION
UPF crashes when processing a Session Establishment Request whose CreateFAR
contains an OuterHeaderCreation IE with only IPv6 (no IPv4 address).
UPF should handle such case gracefully.

The parseFAR function used to dereference a nil or empty IPv4Address when
processing OuterHeaderCreation IE that only contains IPv6 (no IPv4),
triggering an out-of-bounds read in ip2int (parse_far.go:123 → utils.go:67)
and causing UPF to crash.

This change adds validation to check for nil or empty IPv4Address before
attempting to convert it, preventing the crash when processing malformed
PFCP messages.

Fixes #962