### PR TITLE
SonarQube Critical Fixes for Duplicating Literals

### DIFF
--- a/conf/test_route_control.py
+++ b/conf/test_route_control.py
@@ -12,12 +12,15 @@ from conf.route_control import (RouteController, RouteEntry,
                                 fetch_mac, mac_to_hex, mac_to_int,
                                 validate_ipv4)
 
-
+DEFAULT_MAC_ADDRESS  = "00:1a:2b:3c:4d:5e"
 class BessControllerMock(object):
     """Mock of BessController to avoid using BESS from pybess.bess"""
 
     def __init__(self):
         pass
+
+
+
 
     def _get_bess(self, *args, **kwargs) -> None:
         pass
@@ -53,7 +56,7 @@ class TestUtilityFunctions(unittest.TestCase):
         self.assertFalse(validate_ipv4(""))
 
     def test_given_valid_mac_when_mac_to_int_then_returns_int_representation(self):
-        self.assertEqual(mac_to_int("00:1a:2b:3c:4d:5e"), 112394521950)
+        self.assertEqual(mac_to_int(DEFAULT_MAC_ADDRESS), 112394521950)
 
     def test_given_invalid_mac_when_mac_to_int_then_raises_exception(self):
         with self.assertRaises(ValueError):
@@ -62,17 +65,17 @@ class TestUtilityFunctions(unittest.TestCase):
     def test_given_valid_mac_when_mac_to_hex_then_return_hex_string_representation(
         self,
     ):
-        self.assertEqual(mac_to_hex("00:1a:2b:3c:4d:5e"), "001A2B3C4D5E")
+        self.assertEqual(mac_to_hex(DEFAULT_MAC_ADDRESS), "001A2B3C4D5E")
 
     def test_given_known_destination_when_fetch_mac_then_returns_mac(self):
         ndb = Mock()
         kwargs = {
             "ifindex": 1,
             "dst": "192.168.1.1",
-            "lladdr": "00:1a:2b:3c:4d:5e"
+            "lladdr": DEFAULT_MAC_ADDRESS
         }
         ndb.neighbours.dump.return_value = [kwargs]
-        self.assertEqual(fetch_mac(ndb, "192.168.1.1"), "00:1a:2b:3c:4d:5e")
+        self.assertEqual(fetch_mac(ndb, "192.168.1.1"), DEFAULT_MAC_ADDRESS)
 
     def test_given_unknown_destination_when_fetch_mac_then_returns_none(self):
         ndb = Mock()
@@ -114,13 +117,13 @@ class TestRouteController(unittest.TestCase):
         kwargs = {
             "ifindex": 1,
             "dst": "192.168.1.1",
-            "lladdr": "00:1a:2b:3c:4d:5e"
+            "lladdr": DEFAULT_MAC_ADDRESS
         }
         self.ndb.neighbours.dump.return_value = [kwargs]
         mock_get_update_module_name.return_value = "merge_module"
         mock_get_route_module_name.return_value = "route_module"
         mock_get_merge_module_name.return_value = "update_module"
-        mock_fetch_mac.return_value = "00:1a:2b:3c:4d:5e"
+        mock_fetch_mac.return_value = DEFAULT_MAC_ADDRESS
         self.route_controller.add_new_route_entry(route_entry)
         return route_entry
 
@@ -239,7 +242,7 @@ class TestRouteController(unittest.TestCase):
         kwargs = {
             "ifindex": 1,
             "dst": "192.168.1.1",
-            "lladdr": "00:1a:2b:3c:4d:5e"
+            "lladdr": DEFAULT_MAC_ADDRESS
         }
         self.ndb.neighbours.dump.return_value = [kwargs]
         mock_routes = [{"event": "RTM_NEWROUTE"}, {"event": "OTHER_ACTION"}]
@@ -261,7 +264,7 @@ class TestRouteController(unittest.TestCase):
         kwargs = {
             "ifindex": 1,
             "dst": "1.2.3.4",
-            "lladdr": "00:1a:2b:3c:4d:5e"
+            "lladdr": DEFAULT_MAC_ADDRESS
         }
         self.ndb.neighbours.dump.return_value = [kwargs]
         mock_routes = [{"event": "RTM_NEWROUTE"}, {"event": "OTHER_ACTION"}]
@@ -463,13 +466,13 @@ class TestRouteController(unittest.TestCase):
         kwargs = {
             "ifindex": 1,
             "dst": "192.168.1.1",
-            "lladdr": "00:1a:2b:3c:4d:5e"
+            "lladdr": DEFAULT_MAC_ADDRESS
         }
         self.ndb.neighbours.dump.return_value = [kwargs]
         mock_netlink_msg = {
             "attrs": {
                 "NDA_DST": "1.2.3.4",
-                "NDA_LLADDR": "00:1a:2b:3c:4d:5e",
+                "NDA_LLADDR": DEFAULT_MAC_ADDRESS,
             }
         }
         mock_routes = [{"event": "RTM_NEWROUTE"}, {"event": "OTHER_ACTION"}]

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -66,6 +66,16 @@ const (
 	sliceMeterGateUnmeter uint64 = 6
 )
 
+const (
+	// SOnarQube define constants.
+	errGRPCCallFailed    = "unable to make GRPC calls"
+	errMarshalRule       = "error marshalling the rule"
+	errMarshalRequest    = "error marshalling request"
+	errReadFailed        = "read failed:"
+	errInvalidMethodName = "invalid method name:"
+	errMarshalRuleVbl    = "error marshalling the rule %v: %v"
+)
+
 var intEnc = func(u uint64) *pb.FieldData {
 	return &pb.FieldData{Encoding: &pb.FieldData_ValueInt{ValueInt: u}}
 }
@@ -116,7 +126,7 @@ func (b *bess) AddSliceInfo(sliceInfo *SliceInfo) error {
 	rc := b.GRPCJoin(1, Timeout, done)
 
 	if !rc {
-		logger.BessLog.Errorln("unable to make GRPC calls")
+		logger.BessLog.Errorln(errGRPCCallFailed)
 	}
 
 	return nil
@@ -189,7 +199,7 @@ func (b *bess) SendMsgToUPF(
 
 	rc := b.GRPCJoin(calls, Timeout, done)
 	if !rc {
-		logger.BessLog.Errorln("unable to make GRPC calls")
+		logger.BessLog.Errorln(errGRPCCallFailed)
 	}
 
 	return cause
@@ -207,7 +217,7 @@ func (b *bess) measureUpf(ifName string, f *pb.MeasureCommandGetSummaryArg) *pb.
 
 	arg, err := anypb.New(f)
 	if err != nil {
-		logger.BessLog.Errorln("error marshalling the rule", f, err)
+		logger.BessLog.Errorln(errMarshalRule, f, err)
 		return nil
 	}
 
@@ -391,7 +401,7 @@ func (b *bess) flipFlowMeasurementBufferFlag(ctx context.Context, module string)
 
 	arg, err := anypb.New(req)
 	if err != nil {
-		logger.BessLog.Errorln("error marshalling request", req, err)
+		logger.BessLog.Errorln(errMarshalRequest, req, err)
 		return nil, err
 	}
 
@@ -403,7 +413,7 @@ func (b *bess) flipFlowMeasurementBufferFlag(ctx context.Context, module string)
 		},
 	)
 	if err != nil {
-		logger.BessLog.Errorln(module, "read failed:", err)
+		logger.BessLog.Errorln(module, errReadFailed, err)
 		return nil, err
 	}
 
@@ -434,7 +444,7 @@ func (b *bess) readFlowMeasurement(
 
 	arg, err := anypb.New(req)
 	if err != nil {
-		logger.BessLog.Errorln("error marshalling request", req, err)
+		logger.BessLog.Errorln(errMarshalRequest, req, err)
 		return nil, err
 	}
 
@@ -446,7 +456,7 @@ func (b *bess) readFlowMeasurement(
 		},
 	)
 	if err != nil {
-		logger.BessLog.Errorln(module, "read failed:", err)
+		logger.BessLog.Errorln(module, errReadFailed, err)
 		return nil, err
 	}
 
@@ -474,7 +484,7 @@ func (b *bess) readGtpuPathMonitoringStats(
 
 	arg, err := anypb.New(req)
 	if err != nil {
-		logger.BessLog.Errorln("error marshalling request", req, err)
+		logger.BessLog.Errorln(errMarshalRequest, req, err)
 		return nil
 	}
 
@@ -488,7 +498,7 @@ func (b *bess) readGtpuPathMonitoringStats(
 		},
 	)
 	if err != nil {
-		logger.BessLog.Errorln(module, "read failed:", err)
+		logger.BessLog.Errorln(module, errReadFailed, err)
 		return nil
 	}
 
@@ -515,7 +525,7 @@ func (b *bess) SessionStats(pc *PfcpNodeCollector, ch chan<- prometheus.Metric) 
 	// Flips the buffer flag, automatically waits for in-flight packets to drain.
 	flip, err := b.flipFlowMeasurementBufferFlag(ctx, PreQosFlowMeasure)
 	if err != nil {
-		logger.BessLog.Errorln(PreQosFlowMeasure, "read failed:", err)
+		logger.BessLog.Errorln(PreQosFlowMeasure, errReadFailed, err)
 		return err
 	}
 
@@ -524,19 +534,19 @@ func (b *bess) SessionStats(pc *PfcpNodeCollector, ch chan<- prometheus.Metric) 
 	// Read stats from the now inactive side, and clear if needed.
 	qosStatsInResp, err := b.readFlowMeasurement(ctx, PreQosFlowMeasure, flip.OldFlag, true, q)
 	if err != nil {
-		logger.BessLog.Errorln(PreQosFlowMeasure, "read failed:", err)
+		logger.BessLog.Errorln(PreQosFlowMeasure, errReadFailed, err)
 		return err
 	}
 
 	postDlQosStatsResp, err := b.readFlowMeasurement(ctx, PostDlQosFlowMeasure, flip.OldFlag, true, q)
 	if err != nil {
-		logger.BessLog.Errorln(PostDlQosFlowMeasure, "read failed:", err)
+		logger.BessLog.Errorln(PostDlQosFlowMeasure, errReadFailed, err)
 		return err
 	}
 
 	postUlQosStatsResp, err := b.readFlowMeasurement(ctx, PostUlQosFlowMeasure, flip.OldFlag, true, q)
 	if err != nil {
-		logger.BessLog.Errorln(PostUlQosFlowMeasure, "read failed:", err)
+		logger.BessLog.Errorln(PostUlQosFlowMeasure, errReadFailed, err)
 		return err
 	}
 
@@ -722,7 +732,7 @@ func (b *bess) clearState() {
 
 	anyWildcardClear, err := anypb.New(clearWildcardCmd)
 	if err != nil {
-		logger.BessLog.Errorf("error marshalling the rule %v: %v", clearWildcardCmd, err)
+		logger.BessLog.Errorf(errMarshalRuleVbl, clearWildcardCmd, err)
 		return
 	}
 
@@ -732,7 +742,7 @@ func (b *bess) clearState() {
 
 	anyExactClear, err := anypb.New(clearExactCmd)
 	if err != nil {
-		logger.BessLog.Errorf("error marshalling the rule %v: %v", anyExactClear, err)
+		logger.BessLog.Errorf(errMarshalRuleVbl, anyExactClear, err)
 		return
 	}
 
@@ -744,7 +754,7 @@ func (b *bess) clearState() {
 		var anyGtpuPathMonitoringClear *anypb.Any
 		anyGtpuPathMonitoringClear, err = anypb.New(clearGtpuPathMonitoringCmd)
 		if err != nil {
-			logger.BessLog.Errorf("error marshalling the rule %v: %v", anyGtpuPathMonitoringClear, err)
+			logger.BessLog.Errorf(errMarshalRuleVbl, anyGtpuPathMonitoringClear, err)
 			return
 		}
 
@@ -755,7 +765,7 @@ func (b *bess) clearState() {
 	var anyQoSClear *anypb.Any
 	anyQoSClear, err = anypb.New(clearQoSCmd)
 	if err != nil {
-		logger.BessLog.Errorf("error marshalling the rule %v: %v", anyQoSClear, err)
+		logger.BessLog.Errorf(errMarshalRuleVbl, anyQoSClear, err)
 		return
 	}
 
@@ -839,7 +849,7 @@ func (b *bess) SetUpfInfo(u *upf, conf *Conf) {
 
 		rc := b.GRPCJoin(1, Timeout, done)
 		if !rc {
-			logger.BessLog.Errorln("unable to make GRPC calls")
+			logger.BessLog.Errorln(errGRPCCallFailed)
 		}
 	}
 
@@ -850,7 +860,7 @@ func (b *bess) SetUpfInfo(u *upf, conf *Conf) {
 
 func (b *bess) processPDR(ctx context.Context, arg *anypb.Any, method upfMsgType) {
 	if method != upfMsgTypeAdd && method != upfMsgTypeDel && method != upfMsgTypeClear {
-		logger.BessLog.Infoln("invalid method name:", method)
+		logger.BessLog.Infoln(errInvalidMethodName, method)
 		return
 	}
 
@@ -927,7 +937,7 @@ func (b *bess) addPDR(ctx context.Context, done chan<- bool, p pdr) {
 
 			arg, err = anypb.New(f)
 			if err != nil {
-				logger.BessLog.Infoln("error marshalling the rule", f, err)
+				logger.BessLog.Infoln(errMarshalRule, f, err)
 				return
 			}
 
@@ -977,7 +987,7 @@ func (b *bess) delPDR(ctx context.Context, done chan<- bool, p pdr) {
 
 			arg, err = anypb.New(f)
 			if err != nil {
-				logger.BessLog.Errorln("error marshalling the rule", f, err)
+				logger.BessLog.Errorln(errMarshalRule, f, err)
 				return
 			}
 
@@ -1094,7 +1104,7 @@ func (b *bess) addApplicationQER(ctx context.Context, gate uint64, srcIface uint
 
 	arg, err = anypb.New(q)
 	if err != nil {
-		logger.BessLog.Errorln("error marshalling the rule", q, err)
+		logger.BessLog.Errorln(errMarshalRule, q, err)
 		return
 	}
 
@@ -1152,7 +1162,7 @@ func (b *bess) delApplicationQER(
 
 	arg, err = anypb.New(q)
 	if err != nil {
-		logger.BessLog.Infoln("error marshalling the rule", q, err)
+		logger.BessLog.Infoln(errMarshalRule, q, err)
 		return
 	}
 
@@ -1166,7 +1176,7 @@ func (b *bess) delApplicationQER(
 
 func (b *bess) processFAR(ctx context.Context, arg *anypb.Any, method upfMsgType) {
 	if method != upfMsgTypeAdd && method != upfMsgTypeDel && method != upfMsgTypeClear {
-		logger.BessLog.Errorln("invalid method name:", method)
+		logger.BessLog.Errorln(errInvalidMethodName, method)
 		return
 	}
 
@@ -1187,7 +1197,7 @@ func (b *bess) processFAR(ctx context.Context, arg *anypb.Any, method upfMsgType
 
 func (b *bess) processGtpuPathMonitoring(ctx context.Context, arg *anypb.Any, method upfMsgType) {
 	if method != upfMsgTypeAdd && method != upfMsgTypeDel && method != upfMsgTypeClear {
-		logger.BessLog.Errorln("invalid method name:", method)
+		logger.BessLog.Errorln(errInvalidMethodName, method)
 		return
 	}
 
@@ -1252,7 +1262,7 @@ func (b *bess) addFAR(ctx context.Context, done chan<- bool, far far) {
 
 		arg, err = anypb.New(f)
 		if err != nil {
-			logger.BessLog.Infoln("error marshalling the rule", f, err)
+			logger.BessLog.Infoln(errMarshalRule, f, err)
 			return
 		}
 
@@ -1292,7 +1302,7 @@ func (b *bess) delFAR(ctx context.Context, done chan<- bool, far far) {
 
 		arg, err = anypb.New(f)
 		if err != nil {
-			logger.BessLog.Infoln("error marshalling the rule", f, err)
+			logger.BessLog.Infoln(errMarshalRule, f, err)
 			return
 		}
 
@@ -1318,7 +1328,7 @@ func (b *bess) delFAR(ctx context.Context, done chan<- bool, far far) {
 
 func (b *bess) processSliceMeter(ctx context.Context, arg *anypb.Any, method upfMsgType) {
 	if method != upfMsgTypeAdd && method != upfMsgTypeDel && method != upfMsgTypeClear {
-		logger.BessLog.Errorln("invalid method name:", method)
+		logger.BessLog.Errorln(errInvalidMethodName, method)
 		return
 	}
 
@@ -1381,7 +1391,7 @@ func (b *bess) addSliceMeter(ctx context.Context, done chan<- bool, meterConfig 
 
 		arg, err = anypb.New(q)
 		if err != nil {
-			logger.BessLog.Errorln("error marshalling the rule", q, err)
+			logger.BessLog.Errorln(errMarshalRule, q, err)
 			return
 		}
 
@@ -1424,7 +1434,7 @@ func (b *bess) addSliceMeter(ctx context.Context, done chan<- bool, meterConfig 
 
 		arg, err = anypb.New(q)
 		if err != nil {
-			logger.BessLog.Errorln("error marshalling the rule", q, err)
+			logger.BessLog.Errorln(errMarshalRule, q, err)
 			return
 		}
 
@@ -1480,7 +1490,7 @@ func (b *bess) addSessionQER(ctx context.Context, gate uint64, srcIface uint8,
 
 	arg, err = anypb.New(q)
 	if err != nil {
-		logger.BessLog.Errorln("error marshalling the rule", q, err)
+		logger.BessLog.Errorln(errMarshalRule, q, err)
 		return
 	}
 
@@ -1507,7 +1517,7 @@ func (b *bess) delSessionQER(ctx context.Context, srcIface uint8, qer qer) {
 
 	arg, err = anypb.New(q)
 	if err != nil {
-		logger.BessLog.Errorln("error marshalling the rule", q, err)
+		logger.BessLog.Errorln(errMarshalRule, q, err)
 		return
 	}
 


### PR DESCRIPTION
This PR refactors the code to remove duplicated literals for improving maintainability and ensuring compliance with static analysis rules.