### PR TITLE
SonarQube Critical Fixes on pfcpiface package

### DIFF
--- a/pfcpiface/ip_pool_test.go
+++ b/pfcpiface/ip_pool_test.go
@@ -11,13 +11,15 @@ import (
 	"testing"
 )
 
+const ipSubnetCIDR = "10.0.0.0/24"
+
 func TestNewIPPool(t *testing.T) {
 	tests := []struct {
 		name       string
 		poolSubnet string
 		wantErr    bool
 	}{
-		{name: "normal pool", poolSubnet: "10.0.0.0/24", wantErr: false},
+		{name: "normal pool", poolSubnet: ipSubnetCIDR, wantErr: false},
 		{name: "smallest allowed pool", poolSubnet: "10.0.0.0/30", wantErr: false},
 		{name: "IPv6 pool", poolSubnet: "2001::/124", wantErr: false},
 		{name: "too small pool", poolSubnet: "10.0.0.0/32", wantErr: true},
@@ -61,7 +63,7 @@ func TestIPPool_LookupOrAllocIP(t *testing.T) {
 	})
 
 	t.Run("repeated SEID lookups return same IP", func(t *testing.T) {
-		const poolSubnet = "10.0.0.0/24"
+		const poolSubnet = ipSubnetCIDR
 		const seid = 1234
 		pool, err := NewIPPool(poolSubnet)
 		if err != nil {
@@ -84,7 +86,7 @@ func TestIPPool_LookupOrAllocIP(t *testing.T) {
 	})
 
 	t.Run("full subnet allocation", func(t *testing.T) {
-		const poolSubnet = "10.0.0.0/24"
+		const poolSubnet = ipSubnetCIDR
 		const usableAddresses = 256 - 2 // Account for network and broadcast addresses
 		const baseSeid = 1000
 		_, ipnet, err := net.ParseCIDR(poolSubnet)
@@ -154,7 +156,7 @@ func TestIPPool_LookupOrAllocIP(t *testing.T) {
 
 func TestIPPool_DeallocIP(t *testing.T) {
 	t.Run("plain alloc into dealloc", func(t *testing.T) {
-		const poolSubnet = "10.0.0.0/24"
+		const poolSubnet = ipSubnetCIDR
 		const seid = 1234
 		pool, err := NewIPPool(poolSubnet)
 		if err != nil {
@@ -171,7 +173,7 @@ func TestIPPool_DeallocIP(t *testing.T) {
 	})
 
 	t.Run("dealloc non-existent SEIDs fails", func(t *testing.T) {
-		pool, err := NewIPPool("10.0.0.0/24")
+		pool, err := NewIPPool(ipSubnetCIDR)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/pfcpiface/messages_conn.go
+++ b/pfcpiface/messages_conn.go
@@ -12,6 +12,8 @@ import (
 	"github.com/wmnsk/go-pfcp/message"
 )
 
+const msgAssociationSetupResponseFrom = "association Setup Response from"
+
 var (
 	errFlowDescAbsent           = errors.New("flow description not present")
 	errDatapathDown             = errors.New("datapath down")
@@ -209,7 +211,7 @@ func (pConn *PFCPConn) handleAssociationSetupResponse(msg message.Message) error
 	}
 
 	if cause != ie.CauseRequestAccepted {
-		logger.PfcpLog.Errorln("association Setup Response from", addr,
+		logger.PfcpLog.Errorln(msgAssociationSetupResponseFrom, addr,
 			"with Cause:", cause)
 		return errReqRejected
 	}
@@ -236,12 +238,12 @@ func (pConn *PFCPConn) handleAssociationSetupResponse(msg message.Message) error
 
 	if pConn.ts.remote.IsZero() {
 		pConn.ts.remote = ts
-		logger.PfcpLog.Infoln("association Setup Response from", addr,
+		logger.PfcpLog.Infoln(msgAssociationSetupResponseFrom, addr,
 			"with recovery timestamp:", ts)
 	} else if ts.After(pConn.ts.remote) {
 		old := pConn.ts.remote
 		pConn.ts.remote = ts
-		logger.PfcpLog.Warnln("association Setup Response from", addr,
+		logger.PfcpLog.Warnln(msgAssociationSetupResponseFrom, addr,
 			"with newer recovery timestamp:", ts, "older:", old)
 	}
 

--- a/pfcpiface/parse_far_test.go
+++ b/pfcpiface/parse_far_test.go
@@ -19,6 +19,8 @@ type farTestCase struct {
 	description string
 }
 
+const ipAddressIn = "10.0.0.1"
+
 func TestParseFAR(t *testing.T) {
 	createOp, updateOp := create, update
 
@@ -142,7 +144,7 @@ func TestParseFARShouldError(t *testing.T) {
 				ie.NewApplyAction(0),
 				ie.NewUpdateForwardingParameters(
 					ie.NewDestinationInterface(ie.DstInterfaceAccess),
-					ie.NewOuterHeaderCreation(0x100, 100, "10.0.0.1", "", 0, 0, 0),
+					ie.NewOuterHeaderCreation(0x100, 100, ipAddressIn, "", 0, 0, 0),
 				),
 			),
 			expected: &far{
@@ -157,7 +159,7 @@ func TestParseFARShouldError(t *testing.T) {
 				ie.NewApplyAction(ActionDrop),
 				ie.NewUpdateForwardingParameters(
 					ie.NewDestinationInterface(ie.DstInterfaceAccess),
-					ie.NewOuterHeaderCreation(0x100, 100, "10.0.0.1", "", 0, 0, 0),
+					ie.NewOuterHeaderCreation(0x100, 100, ipAddressIn, "", 0, 0, 0),
 				),
 			),
 			expected: &far{
@@ -170,7 +172,7 @@ func TestParseFARShouldError(t *testing.T) {
 			mockFar := &far{}
 			mockUpf := &upf{
 				accessIP: net.ParseIP("192.168.0.1"),
-				coreIP:   net.ParseIP("10.0.0.1"),
+				coreIP:   net.ParseIP(ipAddressIn),
 			}
 
 			err := mockFar.parseFAR(scenario.input, 101, mockUpf, scenario.op)


### PR DESCRIPTION
This PR refactors the code to remove duplicated literals for improving maintainability and ensuring compliance with static analysis rules.

