### PR TITLE
Refactor: define constants for repeated string literals in pfcpiface and fake_bess

### DIFF
--- a/pfcpiface/parse_sdf_test.go
+++ b/pfcpiface/parse_sdf_test.go
@@ -11,6 +11,12 @@ import (
 	"github.com/omec-project/upf-epc/logger"
 )
 
+const (
+	ipRouteCIDR   = "10.0.0.1/32"
+	ipGateway     = "60.60.0.1"
+	ipPeerAddress = "60.60.0.102"
+)
+
 func mustParseCIDRNet(s string) *net.IPNet {
 	_, ipNet, err := net.ParseCIDR(s)
 	if err != nil {
@@ -38,13 +44,13 @@ func Test_endpoint_parseNet(t *testing.T) {
 		{
 			name:    "single IP",
 			args:    "10.0.0.1",
-			want:    endpoint{IPNet: mustParseCIDRNet("10.0.0.1/32")},
+			want:    endpoint{IPNet: mustParseCIDRNet(ipRouteCIDR)},
 			wantErr: false,
 		},
 		{
 			name:    "single IP with /32 net",
-			args:    "10.0.0.1/32",
-			want:    endpoint{IPNet: mustParseCIDRNet("10.0.0.1/32")},
+			args:    ipRouteCIDR,
+			want:    endpoint{IPNet: mustParseCIDRNet(ipRouteCIDR)},
 			wantErr: false,
 		},
 		{
@@ -345,7 +351,7 @@ func Test_parseFlowDesc(t *testing.T) {
 					ports: newWildcardPortRange(),
 				},
 				dst: endpoint{
-					IPNet: newIpv4AddrAsNet("60.60.0.102"),
+					IPNet: newIpv4AddrAsNet(ipPeerAddress),
 					ports: newWildcardPortRange(),
 				},
 			}, wantErr: false,
@@ -365,7 +371,7 @@ func Test_parseFlowDesc(t *testing.T) {
 					ports: newWildcardPortRange(),
 				},
 				dst: endpoint{
-					IPNet: newIpv4AddrAsNet("60.60.0.102"),
+					IPNet: newIpv4AddrAsNet(ipPeerAddress),
 					ports: newWildcardPortRange(),
 				},
 			}, wantErr: false,
@@ -381,7 +387,7 @@ func Test_parseFlowDesc(t *testing.T) {
 				direction: "out",
 				proto:     reservedProto,
 				src: endpoint{
-					IPNet: newIpv4AddrAsNet("60.60.0.1"),
+					IPNet: newIpv4AddrAsNet(ipGateway),
 					ports: newExactMatchPortRange(8888),
 				},
 				dst: endpoint{
@@ -401,7 +407,7 @@ func Test_parseFlowDesc(t *testing.T) {
 				direction: "out",
 				proto:     reservedProto,
 				src: endpoint{
-					IPNet: newIpv4AddrAsNet("60.60.0.1"),
+					IPNet: newIpv4AddrAsNet(ipGateway),
 					ports: newExactMatchPortRange(8888),
 				},
 				dst: endpoint{
@@ -421,11 +427,11 @@ func Test_parseFlowDesc(t *testing.T) {
 				direction: "out",
 				proto:     reservedProto,
 				src: endpoint{
-					IPNet: newIpv4AddrAsNet("60.60.0.1"),
+					IPNet: newIpv4AddrAsNet(ipGateway),
 					ports: newWildcardPortRange(),
 				},
 				dst: endpoint{
-					IPNet: newIpv4AddrAsNet("60.60.0.102"),
+					IPNet: newIpv4AddrAsNet(ipPeerAddress),
 					ports: newExactMatchPortRange(9999),
 				},
 			}, wantErr: false,
@@ -441,11 +447,11 @@ func Test_parseFlowDesc(t *testing.T) {
 				direction: "out",
 				proto:     reservedProto,
 				src: endpoint{
-					IPNet: newIpv4AddrAsNet("60.60.0.1"),
+					IPNet: newIpv4AddrAsNet(ipGateway),
 					ports: newExactMatchPortRange(8888),
 				},
 				dst: endpoint{
-					IPNet: newIpv4AddrAsNet("60.60.0.102"),
+					IPNet: newIpv4AddrAsNet(ipPeerAddress),
 					ports: newExactMatchPortRange(9999),
 				},
 			}, wantErr: false,
@@ -461,11 +467,11 @@ func Test_parseFlowDesc(t *testing.T) {
 				direction: "out",
 				proto:     reservedProto,
 				src: endpoint{
-					IPNet: newIpv4AddrAsNet("60.60.0.1"),
+					IPNet: newIpv4AddrAsNet(ipGateway),
 					ports: newExactMatchPortRange(8888),
 				},
 				dst: endpoint{
-					IPNet: newIpv4AddrAsNet("60.60.0.102"),
+					IPNet: newIpv4AddrAsNet(ipPeerAddress),
 					ports: newExactMatchPortRange(9999),
 				},
 			}, wantErr: false,

--- a/pkg/fake_bess/fake_bess.go
+++ b/pkg/fake_bess/fake_bess.go
@@ -11,6 +11,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+const msgUnexpectedMessageType = "unexpected message type"
+
 type FakeBESS struct {
 	grpcServer *grpc.Server
 	service    *fakeBessService
@@ -55,7 +57,7 @@ func (b *FakeBESS) GetPdrTableEntries() (entries map[uint32][]FakePdr) {
 	for _, m := range msgs {
 		e, ok := m.(*bess_pb.WildcardMatchCommandAddArg)
 		if !ok {
-			panic("unexpected message type")
+			panic(msgUnexpectedMessageType)
 		}
 		pdr := UnmarshalPdr(e)
 		entries[pdr.PdrID] = append(entries[pdr.PdrID], pdr)
@@ -70,7 +72,7 @@ func (b *FakeBESS) GetFarTableEntries() (entries map[uint32]FakeFar) {
 	for _, m := range msgs {
 		e, ok := m.(*bess_pb.ExactMatchCommandAddArg)
 		if !ok {
-			panic("unexpected message type")
+			panic(msgUnexpectedMessageType)
 		}
 		far := UnmarshalFar(e)
 		entries[far.FarID] = far
@@ -84,7 +86,7 @@ func (b *FakeBESS) GetSessionQerTableEntries() (entries []FakeQer) {
 	for _, m := range msgs {
 		e, ok := m.(*bess_pb.QosCommandAddArg)
 		if !ok {
-			panic("unexpected message type")
+			panic(msgUnexpectedMessageType)
 		}
 		entries = append(entries, UnmarshalSessionQer(e))
 	}
@@ -96,7 +98,7 @@ func (b *FakeBESS) GetAppQerTableEntries() (entries []FakeQer) {
 	for _, m := range msgs {
 		e, ok := m.(*bess_pb.QosCommandAddArg)
 		if !ok {
-			panic("unexpected message type")
+			panic(msgUnexpectedMessageType)
 		}
 		entries = append(entries, UnmarshalAppQer(e))
 	}


### PR DESCRIPTION
**Description**
This PR refactors repeated string literals in pfcpiface/parse_sdf_test.go and pkg/fake_bess/fake_bess.go to improve code maintainability and resolve duplication warnings.

**Key Changes**

- Consolidated IP Address Literals (parse_sdf_test.go): Defined constants for frequently duplicated IP and CIDR address string values ("10.0.0.1/32", "60.60.0.102", and "60.60.0.1") used throughout the SDF parsing tests.
- Consolidated Error Literals (fake_bess.go): Substituted duplicated instances of the "unexpected message type" mock assertion message with a dedicated constant.
