### PR TITLE
Fix SonarQube nested comment issues in autogenerated protobuf files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,12 +110,12 @@ pb: $(BUILD_OUTPUT_DIR) ## Generate Go protobuf files
 	@echo "Generating Go protobuf files..."
 	@DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) $(DOCKER_EXTRA_BUILD_ARGS) \
 		--target pb \
-		--output $(BUILD_OUTPUT_DIR) \
+		--output $(BUILD_OUTPUT_DIR) \.
 		.
 	@cp -a $(BUILD_OUTPUT_DIR)/bess_pb $(BESS_PB_DIR)
 	@echo "Fixing SonarQube issues in generated protobuf files..."
 	@go run pfcpiface/tools/fix_sonar_pb.go $(BESS_PB_DIR)/bess_pb
-	
+
 py-pb: $(BUILD_OUTPUT_DIR) ## Generate Python protobuf files
 	@echo "Generating Python protobuf files..."
 	@DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) $(DOCKER_EXTRA_BUILD_ARGS) \

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,8 @@ pb: $(BUILD_OUTPUT_DIR) ## Generate Go protobuf files
 		--output $(BUILD_OUTPUT_DIR) \
 		.
 	@cp -a $(BUILD_OUTPUT_DIR)/bess_pb $(BESS_PB_DIR)
+	@echo "Fixing SonarQube issues in generated protobuf files..."
+	@go run pfcpiface/tools/fix_sonar_pb.go
 
 py-pb: $(BUILD_OUTPUT_DIR) ## Generate Python protobuf files
 	@echo "Generating Python protobuf files..."

--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,8 @@ pb: $(BUILD_OUTPUT_DIR) ## Generate Go protobuf files
 		.
 	@cp -a $(BUILD_OUTPUT_DIR)/bess_pb $(BESS_PB_DIR)
 	@echo "Fixing SonarQube issues in generated protobuf files..."
-	@go run pfcpiface/tools/fix_sonar_pb.go
-
+	@go run pfcpiface/tools/fix_sonar_pb.go $(BESS_PB_DIR)/bess_pb
+	
 py-pb: $(BUILD_OUTPUT_DIR) ## Generate Python protobuf files
 	@echo "Generating Python protobuf files..."
 	@DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) $(DOCKER_EXTRA_BUILD_ARGS) \

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ pb: $(BUILD_OUTPUT_DIR) ## Generate Go protobuf files
 	@echo "Generating Go protobuf files..."
 	@DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) $(DOCKER_EXTRA_BUILD_ARGS) \
 		--target pb \
-		--output $(BUILD_OUTPUT_DIR) \.
+		--output $(BUILD_OUTPUT_DIR) \
 		.
 	@cp -a $(BUILD_OUTPUT_DIR)/bess_pb $(BESS_PB_DIR)
 	@echo "Fixing SonarQube issues in generated protobuf files..."

--- a/pfcpiface/bess_pb/bess_msg.pb.go
+++ b/pfcpiface/bess_pb/bess_msg.pb.go
@@ -79,6 +79,7 @@ func (x *EmptyRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*EmptyRequest) ProtoMessage() {}
 
 func (x *EmptyRequest) ProtoReflect() protoreflect.Message {
@@ -118,6 +119,7 @@ func (x *EmptyResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*EmptyResponse) ProtoMessage() {}
 
 func (x *EmptyResponse) ProtoReflect() protoreflect.Message {
@@ -163,6 +165,7 @@ func (x *VersionResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*VersionResponse) ProtoMessage() {}
 
 func (x *VersionResponse) ProtoReflect() protoreflect.Message {
@@ -214,6 +217,7 @@ func (x *ImportPluginRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ImportPluginRequest) ProtoMessage() {}
 
 func (x *ImportPluginRequest) ProtoReflect() protoreflect.Message {
@@ -258,6 +262,7 @@ func (x *UnloadPluginRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*UnloadPluginRequest) ProtoMessage() {}
 
 func (x *UnloadPluginRequest) ProtoReflect() protoreflect.Message {
@@ -303,6 +308,7 @@ func (x *ListPluginsResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ListPluginsResponse) ProtoMessage() {}
 
 func (x *ListPluginsResponse) ProtoReflect() protoreflect.Message {
@@ -355,6 +361,7 @@ func (x *ListWorkersResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ListWorkersResponse) ProtoMessage() {}
 
 func (x *ListWorkersResponse) ProtoReflect() protoreflect.Message {
@@ -408,6 +415,7 @@ func (x *AddWorkerRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*AddWorkerRequest) ProtoMessage() {}
 
 func (x *AddWorkerRequest) ProtoReflect() protoreflect.Message {
@@ -466,6 +474,7 @@ func (x *DestroyWorkerRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*DestroyWorkerRequest) ProtoMessage() {}
 
 func (x *DestroyWorkerRequest) ProtoReflect() protoreflect.Message {
@@ -534,6 +543,7 @@ func (x *TrafficClass) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*TrafficClass) ProtoMessage() {}
 
 func (x *TrafficClass) ProtoReflect() protoreflect.Message {
@@ -667,8 +677,10 @@ type TrafficClass_Share struct {
 	Share int64 `protobuf:"varint,7,opt,name=share,proto3,oneof"`
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*TrafficClass_Priority) isTrafficClass_Arg() {}
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*TrafficClass_Share) isTrafficClass_Arg() {}
 
 type ListTcsRequest struct {
@@ -691,6 +703,7 @@ func (x *ListTcsRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ListTcsRequest) ProtoMessage() {}
 
 func (x *ListTcsRequest) ProtoReflect() protoreflect.Message {
@@ -736,6 +749,7 @@ func (x *ListTcsResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ListTcsResponse) ProtoMessage() {}
 
 func (x *ListTcsResponse) ProtoReflect() protoreflect.Message {
@@ -790,6 +804,7 @@ func (x *CheckSchedulingConstraintsResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*CheckSchedulingConstraintsResponse) ProtoMessage() {}
 
 func (x *CheckSchedulingConstraintsResponse) ProtoReflect() protoreflect.Message {
@@ -855,6 +870,7 @@ func (x *AddTcRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*AddTcRequest) ProtoMessage() {}
 
 func (x *AddTcRequest) ProtoReflect() protoreflect.Message {
@@ -899,6 +915,7 @@ func (x *UpdateTcParamsRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*UpdateTcParamsRequest) ProtoMessage() {}
 
 func (x *UpdateTcParamsRequest) ProtoReflect() protoreflect.Message {
@@ -943,6 +960,7 @@ func (x *UpdateTcParentRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*UpdateTcParentRequest) ProtoMessage() {}
 
 func (x *UpdateTcParentRequest) ProtoReflect() protoreflect.Message {
@@ -987,6 +1005,7 @@ func (x *GetTcStatsRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetTcStatsRequest) ProtoMessage() {}
 
 func (x *GetTcStatsRequest) ProtoReflect() protoreflect.Message {
@@ -1038,6 +1057,7 @@ func (x *GetTcStatsResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetTcStatsResponse) ProtoMessage() {}
 
 func (x *GetTcStatsResponse) ProtoReflect() protoreflect.Message {
@@ -1118,6 +1138,7 @@ func (x *ListDriversResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ListDriversResponse) ProtoMessage() {}
 
 func (x *ListDriversResponse) ProtoReflect() protoreflect.Message {
@@ -1169,6 +1190,7 @@ func (x *GetDriverInfoRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetDriverInfoRequest) ProtoMessage() {}
 
 func (x *GetDriverInfoRequest) ProtoReflect() protoreflect.Message {
@@ -1216,6 +1238,7 @@ func (x *GetDriverInfoResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetDriverInfoResponse) ProtoMessage() {}
 
 func (x *GetDriverInfoResponse) ProtoReflect() protoreflect.Message {
@@ -1282,6 +1305,7 @@ func (x *ListPortsResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ListPortsResponse) ProtoMessage() {}
 
 func (x *ListPortsResponse) ProtoReflect() protoreflect.Message {
@@ -1350,6 +1374,7 @@ func (x *CreatePortRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*CreatePortRequest) ProtoMessage() {}
 
 func (x *CreatePortRequest) ProtoReflect() protoreflect.Message {
@@ -1444,6 +1469,7 @@ func (x *PortConf) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*PortConf) ProtoMessage() {}
 
 func (x *PortConf) ProtoReflect() protoreflect.Message {
@@ -1503,6 +1529,7 @@ func (x *SetPortConfRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*SetPortConfRequest) ProtoMessage() {}
 
 func (x *SetPortConfRequest) ProtoReflect() protoreflect.Message {
@@ -1554,6 +1581,7 @@ func (x *GetPortConfRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetPortConfRequest) ProtoMessage() {}
 
 func (x *GetPortConfRequest) ProtoReflect() protoreflect.Message {
@@ -1599,6 +1627,7 @@ func (x *GetPortConfResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetPortConfResponse) ProtoMessage() {}
 
 func (x *GetPortConfResponse) ProtoReflect() protoreflect.Message {
@@ -1652,6 +1681,7 @@ func (x *CreatePortResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*CreatePortResponse) ProtoMessage() {}
 
 func (x *CreatePortResponse) ProtoReflect() protoreflect.Message {
@@ -1710,6 +1740,7 @@ func (x *DestroyPortRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*DestroyPortRequest) ProtoMessage() {}
 
 func (x *DestroyPortRequest) ProtoReflect() protoreflect.Message {
@@ -1754,6 +1785,7 @@ func (x *GetPortStatsRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetPortStatsRequest) ProtoMessage() {}
 
 func (x *GetPortStatsRequest) ProtoReflect() protoreflect.Message {
@@ -1801,6 +1833,7 @@ func (x *GetPortStatsResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetPortStatsResponse) ProtoMessage() {}
 
 func (x *GetPortStatsResponse) ProtoReflect() protoreflect.Message {
@@ -1866,6 +1899,7 @@ func (x *GetLinkStatusRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetLinkStatusRequest) ProtoMessage() {}
 
 func (x *GetLinkStatusRequest) ProtoReflect() protoreflect.Message {
@@ -1914,6 +1948,7 @@ func (x *GetLinkStatusResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetLinkStatusResponse) ProtoMessage() {}
 
 func (x *GetLinkStatusResponse) ProtoReflect() protoreflect.Message {
@@ -1987,6 +2022,7 @@ func (x *ListMclassResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ListMclassResponse) ProtoMessage() {}
 
 func (x *ListMclassResponse) ProtoReflect() protoreflect.Message {
@@ -2038,6 +2074,7 @@ func (x *GetMclassInfoRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetMclassInfoRequest) ProtoMessage() {}
 
 func (x *GetMclassInfoRequest) ProtoReflect() protoreflect.Message {
@@ -2086,6 +2123,7 @@ func (x *GetMclassInfoResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetMclassInfoResponse) ProtoMessage() {}
 
 func (x *GetMclassInfoResponse) ProtoReflect() protoreflect.Message {
@@ -2159,6 +2197,7 @@ func (x *ListModulesResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ListModulesResponse) ProtoMessage() {}
 
 func (x *ListModulesResponse) ProtoReflect() protoreflect.Message {
@@ -2218,6 +2257,7 @@ func (x *CreateModuleRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*CreateModuleRequest) ProtoMessage() {}
 
 func (x *CreateModuleRequest) ProtoReflect() protoreflect.Message {
@@ -2277,6 +2317,7 @@ func (x *CreateModuleResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*CreateModuleResponse) ProtoMessage() {}
 
 func (x *CreateModuleResponse) ProtoReflect() protoreflect.Message {
@@ -2328,6 +2369,7 @@ func (x *DestroyModuleRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*DestroyModuleRequest) ProtoMessage() {}
 
 func (x *DestroyModuleRequest) ProtoReflect() protoreflect.Message {
@@ -2372,6 +2414,7 @@ func (x *GetModuleInfoRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetModuleInfoRequest) ProtoMessage() {}
 
 func (x *GetModuleInfoRequest) ProtoReflect() protoreflect.Message {
@@ -2423,6 +2466,7 @@ func (x *GetModuleInfoResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetModuleInfoResponse) ProtoMessage() {}
 
 func (x *GetModuleInfoResponse) ProtoReflect() protoreflect.Message {
@@ -2522,6 +2566,7 @@ func (x *ConnectModulesRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ConnectModulesRequest) ProtoMessage() {}
 
 func (x *ConnectModulesRequest) ProtoReflect() protoreflect.Message {
@@ -2595,6 +2640,7 @@ func (x *DisconnectModulesRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*DisconnectModulesRequest) ProtoMessage() {}
 
 func (x *DisconnectModulesRequest) ProtoReflect() protoreflect.Message {
@@ -2656,6 +2702,7 @@ func (x *MempoolDump) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*MempoolDump) ProtoMessage() {}
 
 func (x *MempoolDump) ProtoReflect() protoreflect.Message {
@@ -2770,6 +2817,7 @@ func (x *DumpMempoolRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*DumpMempoolRequest) ProtoMessage() {}
 
 func (x *DumpMempoolRequest) ProtoReflect() protoreflect.Message {
@@ -2815,6 +2863,7 @@ func (x *DumpMempoolResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*DumpMempoolResponse) ProtoMessage() {}
 
 func (x *DumpMempoolResponse) ProtoReflect() protoreflect.Message {
@@ -2868,6 +2917,7 @@ func (x *CommandRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*CommandRequest) ProtoMessage() {}
 
 func (x *CommandRequest) ProtoReflect() protoreflect.Message {
@@ -2927,6 +2977,7 @@ func (x *CommandResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*CommandResponse) ProtoMessage() {}
 
 func (x *CommandResponse) ProtoReflect() protoreflect.Message {
@@ -2979,6 +3030,7 @@ func (x *ListGateHookClassResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ListGateHookClassResponse) ProtoMessage() {}
 
 func (x *ListGateHookClassResponse) ProtoReflect() protoreflect.Message {
@@ -3030,6 +3082,7 @@ func (x *GetGateHookClassInfoRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetGateHookClassInfoRequest) ProtoMessage() {}
 
 func (x *GetGateHookClassInfoRequest) ProtoReflect() protoreflect.Message {
@@ -3078,6 +3131,7 @@ func (x *GetGateHookClassInfoResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetGateHookClassInfoResponse) ProtoMessage() {}
 
 func (x *GetGateHookClassInfoResponse) ProtoReflect() protoreflect.Message {
@@ -3157,6 +3211,7 @@ func (x *TrackArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*TrackArg) ProtoMessage() {}
 
 func (x *TrackArg) ProtoReflect() protoreflect.Message {
@@ -3211,6 +3266,7 @@ func (x *TcpdumpArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*TcpdumpArg) ProtoMessage() {}
 
 func (x *TcpdumpArg) ProtoReflect() protoreflect.Message {
@@ -3281,6 +3337,7 @@ func (x *PcapngArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*PcapngArg) ProtoMessage() {}
 
 func (x *PcapngArg) ProtoReflect() protoreflect.Message {
@@ -3347,6 +3404,7 @@ func (x *GateHookInfo) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GateHookInfo) ProtoMessage() {}
 
 func (x *GateHookInfo) ProtoReflect() protoreflect.Message {
@@ -3431,8 +3489,10 @@ type GateHookInfo_Ogate struct {
 	Ogate int64 `protobuf:"varint,5,opt,name=ogate,proto3,oneof"` /// Output gate index. All output gates if -1
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GateHookInfo_Igate) isGateHookInfo_Gate() {}
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GateHookInfo_Ogate) isGateHookInfo_Gate() {}
 
 type ConfigureGateHookRequest struct {
@@ -3454,6 +3514,7 @@ func (x *ConfigureGateHookRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ConfigureGateHookRequest) ProtoMessage() {}
 
 func (x *ConfigureGateHookRequest) ProtoReflect() protoreflect.Message {
@@ -3506,6 +3567,7 @@ func (x *ConfigureGateHookResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ConfigureGateHookResponse) ProtoMessage() {}
 
 func (x *ConfigureGateHookResponse) ProtoReflect() protoreflect.Message {
@@ -3558,6 +3620,7 @@ func (x *ListGateHooksResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ListGateHooksResponse) ProtoMessage() {}
 
 func (x *ListGateHooksResponse) ProtoReflect() protoreflect.Message {
@@ -3610,6 +3673,7 @@ func (x *GateHookCommandRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GateHookCommandRequest) ProtoMessage() {}
 
 func (x *GateHookCommandRequest) ProtoReflect() protoreflect.Message {
@@ -3664,6 +3728,7 @@ func (x *ConfigureResumeHookRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ConfigureResumeHookRequest) ProtoMessage() {}
 
 func (x *ConfigureResumeHookRequest) ProtoReflect() protoreflect.Message {
@@ -3722,6 +3787,7 @@ func (x *PauseWorkerRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*PauseWorkerRequest) ProtoMessage() {}
 
 func (x *PauseWorkerRequest) ProtoReflect() protoreflect.Message {
@@ -3766,6 +3832,7 @@ func (x *ResumeWorkerRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ResumeWorkerRequest) ProtoMessage() {}
 
 func (x *ResumeWorkerRequest) ProtoReflect() protoreflect.Message {
@@ -3818,6 +3885,7 @@ func (x *ListWorkersResponse_WorkerStatus) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ListWorkersResponse_WorkerStatus) ProtoMessage() {}
 
 func (x *ListWorkersResponse_WorkerStatus) ProtoReflect() protoreflect.Message {
@@ -3891,6 +3959,7 @@ func (x *ListTcsResponse_TrafficClassStatus) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ListTcsResponse_TrafficClassStatus) ProtoMessage() {}
 
 func (x *ListTcsResponse_TrafficClassStatus) ProtoReflect() protoreflect.Message {
@@ -3945,6 +4014,7 @@ func (x *CheckSchedulingConstraintsResponse_ViolatingClass) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*CheckSchedulingConstraintsResponse_ViolatingClass) ProtoMessage() {}
 
 func (x *CheckSchedulingConstraintsResponse_ViolatingClass) ProtoReflect() protoreflect.Message {
@@ -4010,6 +4080,7 @@ func (x *CheckSchedulingConstraintsResponse_ViolatingModule) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*CheckSchedulingConstraintsResponse_ViolatingModule) ProtoMessage() {}
 
 func (x *CheckSchedulingConstraintsResponse_ViolatingModule) ProtoReflect() protoreflect.Message {
@@ -4067,6 +4138,7 @@ func (x *ListPortsResponse_Port) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ListPortsResponse_Port) ProtoMessage() {}
 
 func (x *ListPortsResponse_Port) ProtoReflect() protoreflect.Message {
@@ -4179,6 +4251,7 @@ func (x *GetPortStatsResponse_Stat) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetPortStatsResponse_Stat) ProtoMessage() {}
 
 func (x *GetPortStatsResponse_Stat) ProtoReflect() protoreflect.Message {
@@ -4260,6 +4333,7 @@ func (x *ListModulesResponse_Module) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ListModulesResponse_Module) ProtoMessage() {}
 
 func (x *ListModulesResponse_Module) ProtoReflect() protoreflect.Message {
@@ -4319,6 +4393,7 @@ func (x *GetModuleInfoResponse_GateHook) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetModuleInfoResponse_GateHook) ProtoMessage() {}
 
 func (x *GetModuleInfoResponse_GateHook) ProtoReflect() protoreflect.Message {
@@ -4376,6 +4451,7 @@ func (x *GetModuleInfoResponse_IGate) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetModuleInfoResponse_IGate) ProtoMessage() {}
 
 func (x *GetModuleInfoResponse_IGate) ProtoReflect() protoreflect.Message {
@@ -4469,6 +4545,7 @@ func (x *GetModuleInfoResponse_OGate) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetModuleInfoResponse_OGate) ProtoMessage() {}
 
 func (x *GetModuleInfoResponse_OGate) ProtoReflect() protoreflect.Message {
@@ -4565,6 +4642,7 @@ func (x *GetModuleInfoResponse_Attribute) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetModuleInfoResponse_Attribute) ProtoMessage() {}
 
 func (x *GetModuleInfoResponse_Attribute) ProtoReflect() protoreflect.Message {
@@ -4631,6 +4709,7 @@ func (x *GetModuleInfoResponse_IGate_OGate) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GetModuleInfoResponse_IGate_OGate) ProtoMessage() {}
 
 func (x *GetModuleInfoResponse_IGate_OGate) ProtoReflect() protoreflect.Message {
@@ -5004,88 +5083,90 @@ func file_bess_msg_proto_rawDescGZIP() []byte {
 	return file_bess_msg_proto_rawDescData
 }
 
-var file_bess_msg_proto_msgTypes = make([]protoimpl.MessageInfo, 77)
-var file_bess_msg_proto_goTypes = []any{
-	(*EmptyRequest)(nil),                                       // 0: bess.pb.EmptyRequest
-	(*EmptyResponse)(nil),                                      // 1: bess.pb.EmptyResponse
-	(*VersionResponse)(nil),                                    // 2: bess.pb.VersionResponse
-	(*ImportPluginRequest)(nil),                                // 3: bess.pb.ImportPluginRequest
-	(*UnloadPluginRequest)(nil),                                // 4: bess.pb.UnloadPluginRequest
-	(*ListPluginsResponse)(nil),                                // 5: bess.pb.ListPluginsResponse
-	(*ListWorkersResponse)(nil),                                // 6: bess.pb.ListWorkersResponse
-	(*AddWorkerRequest)(nil),                                   // 7: bess.pb.AddWorkerRequest
-	(*DestroyWorkerRequest)(nil),                               // 8: bess.pb.DestroyWorkerRequest
-	(*TrafficClass)(nil),                                       // 9: bess.pb.TrafficClass
-	(*ListTcsRequest)(nil),                                     // 10: bess.pb.ListTcsRequest
-	(*ListTcsResponse)(nil),                                    // 11: bess.pb.ListTcsResponse
-	(*CheckSchedulingConstraintsResponse)(nil),                 // 12: bess.pb.CheckSchedulingConstraintsResponse
-	(*AddTcRequest)(nil),                                       // 13: bess.pb.AddTcRequest
-	(*UpdateTcParamsRequest)(nil),                              // 14: bess.pb.UpdateTcParamsRequest
-	(*UpdateTcParentRequest)(nil),                              // 15: bess.pb.UpdateTcParentRequest
-	(*GetTcStatsRequest)(nil),                                  // 16: bess.pb.GetTcStatsRequest
-	(*GetTcStatsResponse)(nil),                                 // 17: bess.pb.GetTcStatsResponse
-	(*ListDriversResponse)(nil),                                // 18: bess.pb.ListDriversResponse
-	(*GetDriverInfoRequest)(nil),                               // 19: bess.pb.GetDriverInfoRequest
-	(*GetDriverInfoResponse)(nil),                              // 20: bess.pb.GetDriverInfoResponse
-	(*ListPortsResponse)(nil),                                  // 21: bess.pb.ListPortsResponse
-	(*CreatePortRequest)(nil),                                  // 22: bess.pb.CreatePortRequest
-	(*PortConf)(nil),                                           // 23: bess.pb.PortConf
-	(*SetPortConfRequest)(nil),                                 // 24: bess.pb.SetPortConfRequest
-	(*GetPortConfRequest)(nil),                                 // 25: bess.pb.GetPortConfRequest
-	(*GetPortConfResponse)(nil),                                // 26: bess.pb.GetPortConfResponse
-	(*CreatePortResponse)(nil),                                 // 27: bess.pb.CreatePortResponse
-	(*DestroyPortRequest)(nil),                                 // 28: bess.pb.DestroyPortRequest
-	(*GetPortStatsRequest)(nil),                                // 29: bess.pb.GetPortStatsRequest
-	(*GetPortStatsResponse)(nil),                               // 30: bess.pb.GetPortStatsResponse
-	(*GetLinkStatusRequest)(nil),                               // 31: bess.pb.GetLinkStatusRequest
-	(*GetLinkStatusResponse)(nil),                              // 32: bess.pb.GetLinkStatusResponse
-	(*ListMclassResponse)(nil),                                 // 33: bess.pb.ListMclassResponse
-	(*GetMclassInfoRequest)(nil),                               // 34: bess.pb.GetMclassInfoRequest
-	(*GetMclassInfoResponse)(nil),                              // 35: bess.pb.GetMclassInfoResponse
-	(*ListModulesResponse)(nil),                                // 36: bess.pb.ListModulesResponse
-	(*CreateModuleRequest)(nil),                                // 37: bess.pb.CreateModuleRequest
-	(*CreateModuleResponse)(nil),                               // 38: bess.pb.CreateModuleResponse
-	(*DestroyModuleRequest)(nil),                               // 39: bess.pb.DestroyModuleRequest
-	(*GetModuleInfoRequest)(nil),                               // 40: bess.pb.GetModuleInfoRequest
-	(*GetModuleInfoResponse)(nil),                              // 41: bess.pb.GetModuleInfoResponse
-	(*ConnectModulesRequest)(nil),                              // 42: bess.pb.ConnectModulesRequest
-	(*DisconnectModulesRequest)(nil),                           // 43: bess.pb.DisconnectModulesRequest
-	(*MempoolDump)(nil),                                        // 44: bess.pb.MempoolDump
-	(*DumpMempoolRequest)(nil),                                 // 45: bess.pb.DumpMempoolRequest
-	(*DumpMempoolResponse)(nil),                                // 46: bess.pb.DumpMempoolResponse
-	(*CommandRequest)(nil),                                     // 47: bess.pb.CommandRequest
-	(*CommandResponse)(nil),                                    // 48: bess.pb.CommandResponse
-	(*ListGateHookClassResponse)(nil),                          // 49: bess.pb.ListGateHookClassResponse
-	(*GetGateHookClassInfoRequest)(nil),                        // 50: bess.pb.GetGateHookClassInfoRequest
-	(*GetGateHookClassInfoResponse)(nil),                       // 51: bess.pb.GetGateHookClassInfoResponse
-	(*TrackArg)(nil),                                           // 52: bess.pb.TrackArg
-	(*TcpdumpArg)(nil),                                         // 53: bess.pb.TcpdumpArg
-	(*PcapngArg)(nil),                                          // 54: bess.pb.PcapngArg
-	(*GateHookInfo)(nil),                                       // 55: bess.pb.GateHookInfo
-	(*ConfigureGateHookRequest)(nil),                           // 56: bess.pb.ConfigureGateHookRequest
-	(*ConfigureGateHookResponse)(nil),                          // 57: bess.pb.ConfigureGateHookResponse
-	(*ListGateHooksResponse)(nil),                              // 58: bess.pb.ListGateHooksResponse
-	(*GateHookCommandRequest)(nil),                             // 59: bess.pb.GateHookCommandRequest
-	(*ConfigureResumeHookRequest)(nil),                         // 60: bess.pb.ConfigureResumeHookRequest
-	(*PauseWorkerRequest)(nil),                                 // 61: bess.pb.PauseWorkerRequest
-	(*ResumeWorkerRequest)(nil),                                // 62: bess.pb.ResumeWorkerRequest
-	(*ListWorkersResponse_WorkerStatus)(nil),                   // 63: bess.pb.ListWorkersResponse.WorkerStatus
-	nil,                                                        // 64: bess.pb.TrafficClass.LimitEntry
-	nil,                                                        // 65: bess.pb.TrafficClass.MaxBurstEntry
-	(*ListTcsResponse_TrafficClassStatus)(nil),                 // 66: bess.pb.ListTcsResponse.TrafficClassStatus
-	(*CheckSchedulingConstraintsResponse_ViolatingClass)(nil),  // 67: bess.pb.CheckSchedulingConstraintsResponse.ViolatingClass
-	(*CheckSchedulingConstraintsResponse_ViolatingModule)(nil), // 68: bess.pb.CheckSchedulingConstraintsResponse.ViolatingModule
-	(*ListPortsResponse_Port)(nil),                             // 69: bess.pb.ListPortsResponse.Port
-	(*GetPortStatsResponse_Stat)(nil),                          // 70: bess.pb.GetPortStatsResponse.Stat
-	(*ListModulesResponse_Module)(nil),                         // 71: bess.pb.ListModulesResponse.Module
-	(*GetModuleInfoResponse_GateHook)(nil),                     // 72: bess.pb.GetModuleInfoResponse.GateHook
-	(*GetModuleInfoResponse_IGate)(nil),                        // 73: bess.pb.GetModuleInfoResponse.IGate
-	(*GetModuleInfoResponse_OGate)(nil),                        // 74: bess.pb.GetModuleInfoResponse.OGate
-	(*GetModuleInfoResponse_Attribute)(nil),                    // 75: bess.pb.GetModuleInfoResponse.Attribute
-	(*GetModuleInfoResponse_IGate_OGate)(nil),                  // 76: bess.pb.GetModuleInfoResponse.IGate.OGate
-	(*Error)(nil),                                              // 77: bess.pb.Error
-	(*anypb.Any)(nil),                                          // 78: google.protobuf.Any
-}
+var (
+	file_bess_msg_proto_msgTypes = make([]protoimpl.MessageInfo, 77)
+	file_bess_msg_proto_goTypes  = []any{
+		(*EmptyRequest)(nil),                                       // 0: bess.pb.EmptyRequest
+		(*EmptyResponse)(nil),                                      // 1: bess.pb.EmptyResponse
+		(*VersionResponse)(nil),                                    // 2: bess.pb.VersionResponse
+		(*ImportPluginRequest)(nil),                                // 3: bess.pb.ImportPluginRequest
+		(*UnloadPluginRequest)(nil),                                // 4: bess.pb.UnloadPluginRequest
+		(*ListPluginsResponse)(nil),                                // 5: bess.pb.ListPluginsResponse
+		(*ListWorkersResponse)(nil),                                // 6: bess.pb.ListWorkersResponse
+		(*AddWorkerRequest)(nil),                                   // 7: bess.pb.AddWorkerRequest
+		(*DestroyWorkerRequest)(nil),                               // 8: bess.pb.DestroyWorkerRequest
+		(*TrafficClass)(nil),                                       // 9: bess.pb.TrafficClass
+		(*ListTcsRequest)(nil),                                     // 10: bess.pb.ListTcsRequest
+		(*ListTcsResponse)(nil),                                    // 11: bess.pb.ListTcsResponse
+		(*CheckSchedulingConstraintsResponse)(nil),                 // 12: bess.pb.CheckSchedulingConstraintsResponse
+		(*AddTcRequest)(nil),                                       // 13: bess.pb.AddTcRequest
+		(*UpdateTcParamsRequest)(nil),                              // 14: bess.pb.UpdateTcParamsRequest
+		(*UpdateTcParentRequest)(nil),                              // 15: bess.pb.UpdateTcParentRequest
+		(*GetTcStatsRequest)(nil),                                  // 16: bess.pb.GetTcStatsRequest
+		(*GetTcStatsResponse)(nil),                                 // 17: bess.pb.GetTcStatsResponse
+		(*ListDriversResponse)(nil),                                // 18: bess.pb.ListDriversResponse
+		(*GetDriverInfoRequest)(nil),                               // 19: bess.pb.GetDriverInfoRequest
+		(*GetDriverInfoResponse)(nil),                              // 20: bess.pb.GetDriverInfoResponse
+		(*ListPortsResponse)(nil),                                  // 21: bess.pb.ListPortsResponse
+		(*CreatePortRequest)(nil),                                  // 22: bess.pb.CreatePortRequest
+		(*PortConf)(nil),                                           // 23: bess.pb.PortConf
+		(*SetPortConfRequest)(nil),                                 // 24: bess.pb.SetPortConfRequest
+		(*GetPortConfRequest)(nil),                                 // 25: bess.pb.GetPortConfRequest
+		(*GetPortConfResponse)(nil),                                // 26: bess.pb.GetPortConfResponse
+		(*CreatePortResponse)(nil),                                 // 27: bess.pb.CreatePortResponse
+		(*DestroyPortRequest)(nil),                                 // 28: bess.pb.DestroyPortRequest
+		(*GetPortStatsRequest)(nil),                                // 29: bess.pb.GetPortStatsRequest
+		(*GetPortStatsResponse)(nil),                               // 30: bess.pb.GetPortStatsResponse
+		(*GetLinkStatusRequest)(nil),                               // 31: bess.pb.GetLinkStatusRequest
+		(*GetLinkStatusResponse)(nil),                              // 32: bess.pb.GetLinkStatusResponse
+		(*ListMclassResponse)(nil),                                 // 33: bess.pb.ListMclassResponse
+		(*GetMclassInfoRequest)(nil),                               // 34: bess.pb.GetMclassInfoRequest
+		(*GetMclassInfoResponse)(nil),                              // 35: bess.pb.GetMclassInfoResponse
+		(*ListModulesResponse)(nil),                                // 36: bess.pb.ListModulesResponse
+		(*CreateModuleRequest)(nil),                                // 37: bess.pb.CreateModuleRequest
+		(*CreateModuleResponse)(nil),                               // 38: bess.pb.CreateModuleResponse
+		(*DestroyModuleRequest)(nil),                               // 39: bess.pb.DestroyModuleRequest
+		(*GetModuleInfoRequest)(nil),                               // 40: bess.pb.GetModuleInfoRequest
+		(*GetModuleInfoResponse)(nil),                              // 41: bess.pb.GetModuleInfoResponse
+		(*ConnectModulesRequest)(nil),                              // 42: bess.pb.ConnectModulesRequest
+		(*DisconnectModulesRequest)(nil),                           // 43: bess.pb.DisconnectModulesRequest
+		(*MempoolDump)(nil),                                        // 44: bess.pb.MempoolDump
+		(*DumpMempoolRequest)(nil),                                 // 45: bess.pb.DumpMempoolRequest
+		(*DumpMempoolResponse)(nil),                                // 46: bess.pb.DumpMempoolResponse
+		(*CommandRequest)(nil),                                     // 47: bess.pb.CommandRequest
+		(*CommandResponse)(nil),                                    // 48: bess.pb.CommandResponse
+		(*ListGateHookClassResponse)(nil),                          // 49: bess.pb.ListGateHookClassResponse
+		(*GetGateHookClassInfoRequest)(nil),                        // 50: bess.pb.GetGateHookClassInfoRequest
+		(*GetGateHookClassInfoResponse)(nil),                       // 51: bess.pb.GetGateHookClassInfoResponse
+		(*TrackArg)(nil),                                           // 52: bess.pb.TrackArg
+		(*TcpdumpArg)(nil),                                         // 53: bess.pb.TcpdumpArg
+		(*PcapngArg)(nil),                                          // 54: bess.pb.PcapngArg
+		(*GateHookInfo)(nil),                                       // 55: bess.pb.GateHookInfo
+		(*ConfigureGateHookRequest)(nil),                           // 56: bess.pb.ConfigureGateHookRequest
+		(*ConfigureGateHookResponse)(nil),                          // 57: bess.pb.ConfigureGateHookResponse
+		(*ListGateHooksResponse)(nil),                              // 58: bess.pb.ListGateHooksResponse
+		(*GateHookCommandRequest)(nil),                             // 59: bess.pb.GateHookCommandRequest
+		(*ConfigureResumeHookRequest)(nil),                         // 60: bess.pb.ConfigureResumeHookRequest
+		(*PauseWorkerRequest)(nil),                                 // 61: bess.pb.PauseWorkerRequest
+		(*ResumeWorkerRequest)(nil),                                // 62: bess.pb.ResumeWorkerRequest
+		(*ListWorkersResponse_WorkerStatus)(nil),                   // 63: bess.pb.ListWorkersResponse.WorkerStatus
+		nil,                                                        // 64: bess.pb.TrafficClass.LimitEntry
+		nil,                                                        // 65: bess.pb.TrafficClass.MaxBurstEntry
+		(*ListTcsResponse_TrafficClassStatus)(nil),                 // 66: bess.pb.ListTcsResponse.TrafficClassStatus
+		(*CheckSchedulingConstraintsResponse_ViolatingClass)(nil),  // 67: bess.pb.CheckSchedulingConstraintsResponse.ViolatingClass
+		(*CheckSchedulingConstraintsResponse_ViolatingModule)(nil), // 68: bess.pb.CheckSchedulingConstraintsResponse.ViolatingModule
+		(*ListPortsResponse_Port)(nil),                             // 69: bess.pb.ListPortsResponse.Port
+		(*GetPortStatsResponse_Stat)(nil),                          // 70: bess.pb.GetPortStatsResponse.Stat
+		(*ListModulesResponse_Module)(nil),                         // 71: bess.pb.ListModulesResponse.Module
+		(*GetModuleInfoResponse_GateHook)(nil),                     // 72: bess.pb.GetModuleInfoResponse.GateHook
+		(*GetModuleInfoResponse_IGate)(nil),                        // 73: bess.pb.GetModuleInfoResponse.IGate
+		(*GetModuleInfoResponse_OGate)(nil),                        // 74: bess.pb.GetModuleInfoResponse.OGate
+		(*GetModuleInfoResponse_Attribute)(nil),                    // 75: bess.pb.GetModuleInfoResponse.Attribute
+		(*GetModuleInfoResponse_IGate_OGate)(nil),                  // 76: bess.pb.GetModuleInfoResponse.IGate.OGate
+		(*Error)(nil),                                              // 77: bess.pb.Error
+		(*anypb.Any)(nil),                                          // 78: google.protobuf.Any
+	}
+)
 var file_bess_msg_proto_depIdxs = []int32{
 	77, // 0: bess.pb.EmptyResponse.error:type_name -> bess.pb.Error
 	77, // 1: bess.pb.VersionResponse.error:type_name -> bess.pb.Error

--- a/pfcpiface/bess_pb/error.pb.go
+++ b/pfcpiface/bess_pb/error.pb.go
@@ -72,6 +72,7 @@ func (x *Error) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*Error) ProtoMessage() {}
 
 func (x *Error) ProtoReflect() protoreflect.Message {
@@ -126,10 +127,12 @@ func file_error_proto_rawDescGZIP() []byte {
 	return file_error_proto_rawDescData
 }
 
-var file_error_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_error_proto_goTypes = []any{
-	(*Error)(nil), // 0: bess.pb.Error
-}
+var (
+	file_error_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+	file_error_proto_goTypes  = []any{
+		(*Error)(nil), // 0: bess.pb.Error
+	}
+)
 var file_error_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/pfcpiface/bess_pb/module_msg.pb.go
+++ b/pfcpiface/bess_pb/module_msg.pb.go
@@ -71,6 +71,7 @@ func (x *EmptyArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*EmptyArg) ProtoMessage() {}
 
 func (x *EmptyArg) ProtoReflect() protoreflect.Message {
@@ -110,6 +111,7 @@ func (x *BPFCommandClearArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*BPFCommandClearArg) ProtoMessage() {}
 
 func (x *BPFCommandClearArg) ProtoReflect() protoreflect.Message {
@@ -156,6 +158,7 @@ func (x *ExactMatchCommandAddArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ExactMatchCommandAddArg) ProtoMessage() {}
 
 func (x *ExactMatchCommandAddArg) ProtoReflect() protoreflect.Message {
@@ -217,6 +220,7 @@ func (x *ExactMatchCommandDeleteArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ExactMatchCommandDeleteArg) ProtoMessage() {}
 
 func (x *ExactMatchCommandDeleteArg) ProtoReflect() protoreflect.Message {
@@ -263,6 +267,7 @@ func (x *ExactMatchCommandClearArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ExactMatchCommandClearArg) ProtoMessage() {}
 
 func (x *ExactMatchCommandClearArg) ProtoReflect() protoreflect.Message {
@@ -304,6 +309,7 @@ func (x *ExactMatchCommandSetDefaultGateArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ExactMatchCommandSetDefaultGateArg) ProtoMessage() {}
 
 func (x *ExactMatchCommandSetDefaultGateArg) ProtoReflect() protoreflect.Message {
@@ -352,6 +358,7 @@ func (x *FlowGenCommandSetBurstArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*FlowGenCommandSetBurstArg) ProtoMessage() {}
 
 func (x *FlowGenCommandSetBurstArg) ProtoReflect() protoreflect.Message {
@@ -405,6 +412,7 @@ func (x *HashLBCommandSetModeArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*HashLBCommandSetModeArg) ProtoMessage() {}
 
 func (x *HashLBCommandSetModeArg) ProtoReflect() protoreflect.Message {
@@ -460,6 +468,7 @@ func (x *HashLBCommandSetGatesArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*HashLBCommandSetGatesArg) ProtoMessage() {}
 
 func (x *HashLBCommandSetGatesArg) ProtoReflect() protoreflect.Message {
@@ -511,6 +520,7 @@ func (x *IPLookupCommandAddArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*IPLookupCommandAddArg) ProtoMessage() {}
 
 func (x *IPLookupCommandAddArg) ProtoReflect() protoreflect.Message {
@@ -574,6 +584,7 @@ func (x *IPLookupCommandDeleteArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*IPLookupCommandDeleteArg) ProtoMessage() {}
 
 func (x *IPLookupCommandDeleteArg) ProtoReflect() protoreflect.Message {
@@ -628,6 +639,7 @@ func (x *IPLookupCommandClearArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*IPLookupCommandClearArg) ProtoMessage() {}
 
 func (x *IPLookupCommandClearArg) ProtoReflect() protoreflect.Message {
@@ -669,6 +681,7 @@ func (x *L2ForwardCommandAddArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*L2ForwardCommandAddArg) ProtoMessage() {}
 
 func (x *L2ForwardCommandAddArg) ProtoReflect() protoreflect.Message {
@@ -716,6 +729,7 @@ func (x *L2ForwardCommandDeleteArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*L2ForwardCommandDeleteArg) ProtoMessage() {}
 
 func (x *L2ForwardCommandDeleteArg) ProtoReflect() protoreflect.Message {
@@ -764,6 +778,7 @@ func (x *L2ForwardCommandSetDefaultGateArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*L2ForwardCommandSetDefaultGateArg) ProtoMessage() {}
 
 func (x *L2ForwardCommandSetDefaultGateArg) ProtoReflect() protoreflect.Message {
@@ -811,6 +826,7 @@ func (x *L2ForwardCommandLookupArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*L2ForwardCommandLookupArg) ProtoMessage() {}
 
 func (x *L2ForwardCommandLookupArg) ProtoReflect() protoreflect.Message {
@@ -859,6 +875,7 @@ func (x *L2ForwardCommandLookupResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*L2ForwardCommandLookupResponse) ProtoMessage() {}
 
 func (x *L2ForwardCommandLookupResponse) ProtoReflect() protoreflect.Message {
@@ -914,6 +931,7 @@ func (x *L2ForwardCommandPopulateArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*L2ForwardCommandPopulateArg) ProtoMessage() {}
 
 func (x *L2ForwardCommandPopulateArg) ProtoReflect() protoreflect.Message {
@@ -982,6 +1000,7 @@ func (x *MeasureCommandGetSummaryArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*MeasureCommandGetSummaryArg) ProtoMessage() {}
 
 func (x *MeasureCommandGetSummaryArg) ProtoReflect() protoreflect.Message {
@@ -1051,6 +1070,7 @@ func (x *MeasureCommandGetSummaryResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*MeasureCommandGetSummaryResponse) ProtoMessage() {}
 
 func (x *MeasureCommandGetSummaryResponse) ProtoReflect() protoreflect.Message {
@@ -1132,6 +1152,7 @@ func (x *DRRArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*DRRArg) ProtoMessage() {}
 
 func (x *DRRArg) ProtoReflect() protoreflect.Message {
@@ -1192,6 +1213,7 @@ func (x *DRRQuantumArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*DRRQuantumArg) ProtoMessage() {}
 
 func (x *DRRQuantumArg) ProtoReflect() protoreflect.Message {
@@ -1240,6 +1262,7 @@ func (x *DRRMaxFlowQueueSizeArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*DRRMaxFlowQueueSizeArg) ProtoMessage() {}
 
 func (x *DRRMaxFlowQueueSizeArg) ProtoReflect() protoreflect.Message {
@@ -1288,6 +1311,7 @@ func (x *PortIncCommandSetBurstArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*PortIncCommandSetBurstArg) ProtoMessage() {}
 
 func (x *PortIncCommandSetBurstArg) ProtoReflect() protoreflect.Message {
@@ -1336,6 +1360,7 @@ func (x *QueueIncCommandSetBurstArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*QueueIncCommandSetBurstArg) ProtoMessage() {}
 
 func (x *QueueIncCommandSetBurstArg) ProtoReflect() protoreflect.Message {
@@ -1384,6 +1409,7 @@ func (x *QueueCommandSetBurstArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*QueueCommandSetBurstArg) ProtoMessage() {}
 
 func (x *QueueCommandSetBurstArg) ProtoReflect() protoreflect.Message {
@@ -1431,6 +1457,7 @@ func (x *QueueCommandSetSizeArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*QueueCommandSetSizeArg) ProtoMessage() {}
 
 func (x *QueueCommandSetSizeArg) ProtoReflect() protoreflect.Message {
@@ -1477,6 +1504,7 @@ func (x *QueueCommandGetStatusArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*QueueCommandGetStatusArg) ProtoMessage() {}
 
 func (x *QueueCommandGetStatusArg) ProtoReflect() protoreflect.Message {
@@ -1522,6 +1550,7 @@ func (x *QueueCommandGetStatusResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*QueueCommandGetStatusResponse) ProtoMessage() {}
 
 func (x *QueueCommandGetStatusResponse) ProtoReflect() protoreflect.Message {
@@ -1596,6 +1625,7 @@ func (x *RandomUpdateCommandClearArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*RandomUpdateCommandClearArg) ProtoMessage() {}
 
 func (x *RandomUpdateCommandClearArg) ProtoReflect() protoreflect.Message {
@@ -1635,6 +1665,7 @@ func (x *RewriteCommandClearArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*RewriteCommandClearArg) ProtoMessage() {}
 
 func (x *RewriteCommandClearArg) ProtoReflect() protoreflect.Message {
@@ -1674,6 +1705,7 @@ func (x *UpdateCommandClearArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*UpdateCommandClearArg) ProtoMessage() {}
 
 func (x *UpdateCommandClearArg) ProtoReflect() protoreflect.Message {
@@ -1721,6 +1753,7 @@ func (x *WildcardMatchCommandAddArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*WildcardMatchCommandAddArg) ProtoMessage() {}
 
 func (x *WildcardMatchCommandAddArg) ProtoReflect() protoreflect.Message {
@@ -1798,6 +1831,7 @@ func (x *WildcardMatchCommandDeleteArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*WildcardMatchCommandDeleteArg) ProtoMessage() {}
 
 func (x *WildcardMatchCommandDeleteArg) ProtoReflect() protoreflect.Message {
@@ -1852,6 +1886,7 @@ func (x *WildcardMatchCommandClearArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*WildcardMatchCommandClearArg) ProtoMessage() {}
 
 func (x *WildcardMatchCommandClearArg) ProtoReflect() protoreflect.Message {
@@ -1893,6 +1928,7 @@ func (x *WildcardMatchCommandSetDefaultGateArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*WildcardMatchCommandSetDefaultGateArg) ProtoMessage() {}
 
 func (x *WildcardMatchCommandSetDefaultGateArg) ProtoReflect() protoreflect.Message {
@@ -1945,6 +1981,7 @@ func (x *ACLArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ACLArg) ProtoMessage() {}
 
 func (x *ACLArg) ProtoReflect() protoreflect.Message {
@@ -1995,6 +2032,7 @@ func (x *BPFArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*BPFArg) ProtoMessage() {}
 
 func (x *BPFArg) ProtoReflect() protoreflect.Message {
@@ -2046,6 +2084,7 @@ func (x *BufferArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*BufferArg) ProtoMessage() {}
 
 func (x *BufferArg) ProtoReflect() protoreflect.Message {
@@ -2092,6 +2131,7 @@ func (x *BypassArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*BypassArg) ProtoMessage() {}
 
 func (x *BypassArg) ProtoReflect() protoreflect.Message {
@@ -2157,6 +2197,7 @@ func (x *DumpArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*DumpArg) ProtoMessage() {}
 
 func (x *DumpArg) ProtoReflect() protoreflect.Message {
@@ -2209,6 +2250,7 @@ func (x *EtherEncapArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*EtherEncapArg) ProtoMessage() {}
 
 func (x *EtherEncapArg) ProtoReflect() protoreflect.Message {
@@ -2261,6 +2303,7 @@ func (x *ExactMatchArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ExactMatchArg) ProtoMessage() {}
 
 func (x *ExactMatchArg) ProtoReflect() protoreflect.Message {
@@ -2338,6 +2381,7 @@ func (x *ExactMatchConfig) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ExactMatchConfig) ProtoMessage() {}
 
 func (x *ExactMatchConfig) ProtoReflect() protoreflect.Message {
@@ -2421,6 +2465,7 @@ func (x *FlowGenArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*FlowGenArg) ProtoMessage() {}
 
 func (x *FlowGenArg) ProtoReflect() protoreflect.Message {
@@ -2540,6 +2585,7 @@ func (x *GenericDecapArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GenericDecapArg) ProtoMessage() {}
 
 func (x *GenericDecapArg) ProtoReflect() protoreflect.Message {
@@ -2606,6 +2652,7 @@ func (x *GenericEncapArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GenericEncapArg) ProtoMessage() {}
 
 func (x *GenericEncapArg) ProtoReflect() protoreflect.Message {
@@ -2659,6 +2706,7 @@ func (x *HashLBArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*HashLBArg) ProtoMessage() {}
 
 func (x *HashLBArg) ProtoReflect() protoreflect.Message {
@@ -2723,6 +2771,7 @@ func (x *IPEncapArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*IPEncapArg) ProtoMessage() {}
 
 func (x *IPEncapArg) ProtoReflect() protoreflect.Message {
@@ -2768,6 +2817,7 @@ func (x *IPLookupArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*IPLookupArg) ProtoMessage() {}
 
 func (x *IPLookupArg) ProtoReflect() protoreflect.Message {
@@ -2828,6 +2878,7 @@ func (x *L2ForwardArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*L2ForwardArg) ProtoMessage() {}
 
 func (x *L2ForwardArg) ProtoReflect() protoreflect.Message {
@@ -2884,6 +2935,7 @@ func (x *MACSwapArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*MACSwapArg) ProtoMessage() {}
 
 func (x *MACSwapArg) ProtoReflect() protoreflect.Message {
@@ -2942,6 +2994,7 @@ func (x *MeasureArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*MeasureArg) ProtoMessage() {}
 
 func (x *MeasureArg) ProtoReflect() protoreflect.Message {
@@ -3020,8 +3073,10 @@ type MeasureArg_AttrName struct {
 	AttrName string `protobuf:"bytes,6,opt,name=attr_name,json=attrName,proto3,oneof"` /// Where to store the current time as attribute
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*MeasureArg_Offset) isMeasureArg_Type() {}
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*MeasureArg_AttrName) isMeasureArg_Type() {}
 
 // *
@@ -3047,6 +3102,7 @@ func (x *MergeArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*MergeArg) ProtoMessage() {}
 
 func (x *MergeArg) ProtoReflect() protoreflect.Message {
@@ -3088,6 +3144,7 @@ func (x *MetadataTestArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*MetadataTestArg) ProtoMessage() {}
 
 func (x *MetadataTestArg) ProtoReflect() protoreflect.Message {
@@ -3160,6 +3217,7 @@ func (x *NATArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*NATArg) ProtoMessage() {}
 
 func (x *NATArg) ProtoReflect() protoreflect.Message {
@@ -3225,6 +3283,7 @@ func (x *StaticNATArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*StaticNATArg) ProtoMessage() {}
 
 func (x *StaticNATArg) ProtoReflect() protoreflect.Message {
@@ -3270,6 +3329,7 @@ func (x *NoOpArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*NoOpArg) ProtoMessage() {}
 
 func (x *NoOpArg) ProtoReflect() protoreflect.Message {
@@ -3316,6 +3376,7 @@ func (x *PortIncArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*PortIncArg) ProtoMessage() {}
 
 func (x *PortIncArg) ProtoReflect() protoreflect.Message {
@@ -3374,6 +3435,7 @@ func (x *PortOutArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*PortOutArg) ProtoMessage() {}
 
 func (x *PortOutArg) ProtoReflect() protoreflect.Message {
@@ -3428,6 +3490,7 @@ func (x *QueueIncArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*QueueIncArg) ProtoMessage() {}
 
 func (x *QueueIncArg) ProtoReflect() protoreflect.Message {
@@ -3495,6 +3558,7 @@ func (x *QueueOutArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*QueueOutArg) ProtoMessage() {}
 
 func (x *QueueOutArg) ProtoReflect() protoreflect.Message {
@@ -3555,6 +3619,7 @@ func (x *QueueArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*QueueArg) ProtoMessage() {}
 
 func (x *QueueArg) ProtoReflect() protoreflect.Message {
@@ -3619,6 +3684,7 @@ func (x *RandomSplitArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*RandomSplitArg) ProtoMessage() {}
 
 func (x *RandomSplitArg) ProtoReflect() protoreflect.Message {
@@ -3673,6 +3739,7 @@ func (x *RandomSplitCommandSetDroprateArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*RandomSplitCommandSetDroprateArg) ProtoMessage() {}
 
 func (x *RandomSplitCommandSetDroprateArg) ProtoReflect() protoreflect.Message {
@@ -3720,6 +3787,7 @@ func (x *RandomSplitCommandSetGatesArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*RandomSplitCommandSetGatesArg) ProtoMessage() {}
 
 func (x *RandomSplitCommandSetGatesArg) ProtoReflect() protoreflect.Message {
@@ -3770,6 +3838,7 @@ func (x *RandomUpdateArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*RandomUpdateArg) ProtoMessage() {}
 
 func (x *RandomUpdateArg) ProtoReflect() protoreflect.Message {
@@ -3821,6 +3890,7 @@ func (x *RewriteArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*RewriteArg) ProtoMessage() {}
 
 func (x *RewriteArg) ProtoReflect() protoreflect.Message {
@@ -3868,6 +3938,7 @@ func (x *RoundRobinCommandSetGatesArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*RoundRobinCommandSetGatesArg) ProtoMessage() {}
 
 func (x *RoundRobinCommandSetGatesArg) ProtoReflect() protoreflect.Message {
@@ -3915,6 +3986,7 @@ func (x *RoundRobinCommandSetModeArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*RoundRobinCommandSetModeArg) ProtoMessage() {}
 
 func (x *RoundRobinCommandSetModeArg) ProtoReflect() protoreflect.Message {
@@ -3966,6 +4038,7 @@ func (x *RoundRobinArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*RoundRobinArg) ProtoMessage() {}
 
 func (x *RoundRobinArg) ProtoReflect() protoreflect.Message {
@@ -4023,6 +4096,7 @@ func (x *ReplicateArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ReplicateArg) ProtoMessage() {}
 
 func (x *ReplicateArg) ProtoReflect() protoreflect.Message {
@@ -4070,6 +4144,7 @@ func (x *ReplicateCommandSetGatesArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ReplicateCommandSetGatesArg) ProtoMessage() {}
 
 func (x *ReplicateCommandSetGatesArg) ProtoReflect() protoreflect.Message {
@@ -4121,6 +4196,7 @@ func (x *SetMetadataArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*SetMetadataArg) ProtoMessage() {}
 
 func (x *SetMetadataArg) ProtoReflect() protoreflect.Message {
@@ -4169,6 +4245,7 @@ func (x *SinkArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*SinkArg) ProtoMessage() {}
 
 func (x *SinkArg) ProtoReflect() protoreflect.Message {
@@ -4210,6 +4287,7 @@ func (x *SourceCommandSetBurstArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*SourceCommandSetBurstArg) ProtoMessage() {}
 
 func (x *SourceCommandSetBurstArg) ProtoReflect() protoreflect.Message {
@@ -4257,6 +4335,7 @@ func (x *SourceCommandSetPktSizeArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*SourceCommandSetPktSizeArg) ProtoMessage() {}
 
 func (x *SourceCommandSetPktSizeArg) ProtoReflect() protoreflect.Message {
@@ -4306,6 +4385,7 @@ func (x *SourceArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*SourceArg) ProtoMessage() {}
 
 func (x *SourceArg) ProtoReflect() protoreflect.Message {
@@ -4359,6 +4439,7 @@ func (x *IPChecksumArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*IPChecksumArg) ProtoMessage() {}
 
 func (x *IPChecksumArg) ProtoReflect() protoreflect.Message {
@@ -4419,6 +4500,7 @@ func (x *L4ChecksumArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*L4ChecksumArg) ProtoMessage() {}
 
 func (x *L4ChecksumArg) ProtoReflect() protoreflect.Message {
@@ -4477,6 +4559,7 @@ func (x *GtpuEchoArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GtpuEchoArg) ProtoMessage() {}
 
 func (x *GtpuEchoArg) ProtoReflect() protoreflect.Message {
@@ -4529,6 +4612,7 @@ func (x *IPDefragArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*IPDefragArg) ProtoMessage() {}
 
 func (x *IPDefragArg) ProtoReflect() protoreflect.Message {
@@ -4586,6 +4670,7 @@ func (x *IPFragArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*IPFragArg) ProtoMessage() {}
 
 func (x *IPFragArg) ProtoReflect() protoreflect.Message {
@@ -4635,6 +4720,7 @@ func (x *CounterAddArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*CounterAddArg) ProtoMessage() {}
 
 func (x *CounterAddArg) ProtoReflect() protoreflect.Message {
@@ -4684,6 +4770,7 @@ func (x *CounterRemoveArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*CounterRemoveArg) ProtoMessage() {}
 
 func (x *CounterRemoveArg) ProtoReflect() protoreflect.Message {
@@ -4736,6 +4823,7 @@ func (x *CounterArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*CounterArg) ProtoMessage() {}
 
 func (x *CounterArg) ProtoReflect() protoreflect.Message {
@@ -4799,6 +4887,7 @@ func (x *GtpuEncapArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GtpuEncapArg) ProtoMessage() {}
 
 func (x *GtpuEncapArg) ProtoReflect() protoreflect.Message {
@@ -4855,6 +4944,7 @@ func (x *SplitArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*SplitArg) ProtoMessage() {}
 
 func (x *SplitArg) ProtoReflect() protoreflect.Message {
@@ -4918,8 +5008,10 @@ type SplitArg_Offset struct {
 	Offset int64 `protobuf:"varint,3,opt,name=offset,proto3,oneof"` /// The offset (in bytes) of the data field to read.
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*SplitArg_Attribute) isSplitArg_Type() {}
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*SplitArg_Offset) isSplitArg_Type() {}
 
 // *
@@ -4952,6 +5044,7 @@ func (x *TimestampArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*TimestampArg) ProtoMessage() {}
 
 func (x *TimestampArg) ProtoReflect() protoreflect.Message {
@@ -5008,8 +5101,10 @@ type TimestampArg_AttrName struct {
 	AttrName string `protobuf:"bytes,2,opt,name=attr_name,json=attrName,proto3,oneof"`
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*TimestampArg_Offset) isTimestampArg_Type() {}
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*TimestampArg_AttrName) isTimestampArg_Type() {}
 
 // *
@@ -5035,6 +5130,7 @@ func (x *UpdateArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*UpdateArg) ProtoMessage() {}
 
 func (x *UpdateArg) ProtoReflect() protoreflect.Message {
@@ -5088,6 +5184,7 @@ func (x *UrlFilterArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*UrlFilterArg) ProtoMessage() {}
 
 func (x *UrlFilterArg) ProtoReflect() protoreflect.Message {
@@ -5137,6 +5234,7 @@ func (x *UrlFilterConfig) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*UrlFilterConfig) ProtoMessage() {}
 
 func (x *UrlFilterConfig) ProtoReflect() protoreflect.Message {
@@ -5185,6 +5283,7 @@ func (x *VLANPopArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*VLANPopArg) ProtoMessage() {}
 
 func (x *VLANPopArg) ProtoReflect() protoreflect.Message {
@@ -5227,6 +5326,7 @@ func (x *VLANPushArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*VLANPushArg) ProtoMessage() {}
 
 func (x *VLANPushArg) ProtoReflect() protoreflect.Message {
@@ -5276,6 +5376,7 @@ func (x *VLANSplitArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*VLANSplitArg) ProtoMessage() {}
 
 func (x *VLANSplitArg) ProtoReflect() protoreflect.Message {
@@ -5317,6 +5418,7 @@ func (x *VXLANDecapArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*VXLANDecapArg) ProtoMessage() {}
 
 func (x *VXLANDecapArg) ProtoReflect() protoreflect.Message {
@@ -5360,6 +5462,7 @@ func (x *VXLANEncapArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*VXLANEncapArg) ProtoMessage() {}
 
 func (x *VXLANEncapArg) ProtoReflect() protoreflect.Message {
@@ -5416,6 +5519,7 @@ func (x *WildcardMatchArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*WildcardMatchArg) ProtoMessage() {}
 
 func (x *WildcardMatchArg) ProtoReflect() protoreflect.Message {
@@ -5479,6 +5583,7 @@ func (x *WildcardMatchConfig) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*WildcardMatchConfig) ProtoMessage() {}
 
 func (x *WildcardMatchConfig) ProtoReflect() protoreflect.Message {
@@ -5539,6 +5644,7 @@ func (x *ArpResponderArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ArpResponderArg) ProtoMessage() {}
 
 func (x *ArpResponderArg) ProtoReflect() protoreflect.Message {
@@ -5596,6 +5702,7 @@ func (x *MplsPopArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*MplsPopArg) ProtoMessage() {}
 
 func (x *MplsPopArg) ProtoReflect() protoreflect.Message {
@@ -5661,6 +5768,7 @@ func (x *WorkerSplitArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*WorkerSplitArg) ProtoMessage() {}
 
 func (x *WorkerSplitArg) ProtoReflect() protoreflect.Message {
@@ -5707,6 +5815,7 @@ func (x *QosArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*QosArg) ProtoMessage() {}
 
 func (x *QosArg) ProtoReflect() protoreflect.Message {
@@ -5776,6 +5885,7 @@ func (x *QosCommandAddArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*QosCommandAddArg) ProtoMessage() {}
 
 func (x *QosCommandAddArg) ProtoReflect() protoreflect.Message {
@@ -5875,6 +5985,7 @@ type QosCommandAddArg_DeductLen struct {
 	DeductLen int64 `protobuf:"varint,9,opt,name=deduct_len,json=deductLen,proto3,oneof"`
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*QosCommandAddArg_DeductLen) isQosCommandAddArg_OptionalDeductLen() {}
 
 type QosCommandDeleteArg struct {
@@ -5895,6 +6006,7 @@ func (x *QosCommandDeleteArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*QosCommandDeleteArg) ProtoMessage() {}
 
 func (x *QosCommandDeleteArg) ProtoReflect() protoreflect.Message {
@@ -5942,6 +6054,7 @@ func (x *QosCommandClearArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*QosCommandClearArg) ProtoMessage() {}
 
 func (x *QosCommandClearArg) ProtoReflect() protoreflect.Message {
@@ -5983,6 +6096,7 @@ func (x *QosCommandSetDefaultGateArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*QosCommandSetDefaultGateArg) ProtoMessage() {}
 
 func (x *QosCommandSetDefaultGateArg) ProtoReflect() protoreflect.Message {
@@ -6029,6 +6143,7 @@ func (x *FlowMeasureArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*FlowMeasureArg) ProtoMessage() {}
 
 func (x *FlowMeasureArg) ProtoReflect() protoreflect.Message {
@@ -6090,6 +6205,7 @@ func (x *FlowMeasureCommandReadArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*FlowMeasureCommandReadArg) ProtoMessage() {}
 
 func (x *FlowMeasureCommandReadArg) ProtoReflect() protoreflect.Message {
@@ -6155,6 +6271,7 @@ func (x *FlowMeasureReadResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*FlowMeasureReadResponse) ProtoMessage() {}
 
 func (x *FlowMeasureReadResponse) ProtoReflect() protoreflect.Message {
@@ -6198,6 +6315,7 @@ func (x *FlowMeasureCommandFlipArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*FlowMeasureCommandFlipArg) ProtoMessage() {}
 
 func (x *FlowMeasureCommandFlipArg) ProtoReflect() protoreflect.Message {
@@ -6235,6 +6353,7 @@ func (x *FlowMeasureFlipResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*FlowMeasureFlipResponse) ProtoMessage() {}
 
 func (x *FlowMeasureFlipResponse) ProtoReflect() protoreflect.Message {
@@ -6282,6 +6401,7 @@ func (x *GtpuPathMonitoringCommandAddDeleteArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GtpuPathMonitoringCommandAddDeleteArg) ProtoMessage() {}
 
 func (x *GtpuPathMonitoringCommandAddDeleteArg) ProtoReflect() protoreflect.Message {
@@ -6329,6 +6449,7 @@ func (x *GtpuPathMonitoringCommandClearArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GtpuPathMonitoringCommandClearArg) ProtoMessage() {}
 
 func (x *GtpuPathMonitoringCommandClearArg) ProtoReflect() protoreflect.Message {
@@ -6370,6 +6491,7 @@ func (x *GtpuPathMonitoringCommandReadArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GtpuPathMonitoringCommandReadArg) ProtoMessage() {}
 
 func (x *GtpuPathMonitoringCommandReadArg) ProtoReflect() protoreflect.Message {
@@ -6417,6 +6539,7 @@ func (x *GtpuPathMonitoringCommandReadResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GtpuPathMonitoringCommandReadResponse) ProtoMessage() {}
 
 func (x *GtpuPathMonitoringCommandReadResponse) ProtoReflect() protoreflect.Message {
@@ -6462,6 +6585,7 @@ func (x *L2ForwardCommandAddArg_Entry) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*L2ForwardCommandAddArg_Entry) ProtoMessage() {}
 
 func (x *L2ForwardCommandAddArg_Entry) ProtoReflect() protoreflect.Message {
@@ -6520,6 +6644,7 @@ func (x *MeasureCommandGetSummaryResponse_Histogram) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*MeasureCommandGetSummaryResponse_Histogram) ProtoMessage() {}
 
 func (x *MeasureCommandGetSummaryResponse_Histogram) ProtoReflect() protoreflect.Message {
@@ -6620,6 +6745,7 @@ func (x *ACLArg_Rule) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*ACLArg_Rule) ProtoMessage() {}
 
 func (x *ACLArg_Rule) ProtoReflect() protoreflect.Message {
@@ -6706,6 +6832,7 @@ func (x *BPFArg_Filter) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*BPFArg_Filter) ProtoMessage() {}
 
 func (x *BPFArg_Filter) ProtoReflect() protoreflect.Message {
@@ -6771,6 +6898,7 @@ func (x *GenericEncapArg_EncapField) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GenericEncapArg_EncapField) ProtoMessage() {}
 
 func (x *GenericEncapArg_EncapField) ProtoReflect() protoreflect.Message {
@@ -6834,8 +6962,10 @@ type GenericEncapArg_EncapField_Value struct {
 	Value *FieldData `protobuf:"bytes,3,opt,name=value,proto3,oneof"` /// Or, the fixed value to insert into the packet.
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GenericEncapArg_EncapField_Attribute) isGenericEncapArg_EncapField_Insertion() {}
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GenericEncapArg_EncapField_Value) isGenericEncapArg_EncapField_Insertion() {}
 
 type NATArg_PortRange struct {
@@ -6858,6 +6988,7 @@ func (x *NATArg_PortRange) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*NATArg_PortRange) ProtoMessage() {}
 
 func (x *NATArg_PortRange) ProtoReflect() protoreflect.Message {
@@ -6917,6 +7048,7 @@ func (x *NATArg_ExternalAddress) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*NATArg_ExternalAddress) ProtoMessage() {}
 
 func (x *NATArg_ExternalAddress) ProtoReflect() protoreflect.Message {
@@ -6969,6 +7101,7 @@ func (x *StaticNATArg_AddressRange) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*StaticNATArg_AddressRange) ProtoMessage() {}
 
 func (x *StaticNATArg_AddressRange) ProtoReflect() protoreflect.Message {
@@ -7021,6 +7154,7 @@ func (x *StaticNATArg_AddressRangePair) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*StaticNATArg_AddressRangePair) ProtoMessage() {}
 
 func (x *StaticNATArg_AddressRangePair) ProtoReflect() protoreflect.Message {
@@ -7078,6 +7212,7 @@ func (x *RandomUpdateArg_Field) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*RandomUpdateArg_Field) ProtoMessage() {}
 
 func (x *RandomUpdateArg_Field) ProtoReflect() protoreflect.Message {
@@ -7160,6 +7295,7 @@ func (x *SetMetadataArg_Attribute) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*SetMetadataArg_Attribute) ProtoMessage() {}
 
 func (x *SetMetadataArg_Attribute) ProtoReflect() protoreflect.Message {
@@ -7251,8 +7387,10 @@ type SetMetadataArg_Attribute_ValueBin struct {
 	ValueBin []byte `protobuf:"bytes,4,opt,name=value_bin,json=valueBin,proto3,oneof"` /// A binary value to store in the packet (host-order).
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*SetMetadataArg_Attribute_ValueInt) isSetMetadataArg_Attribute_Value() {}
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*SetMetadataArg_Attribute_ValueBin) isSetMetadataArg_Attribute_Value() {}
 
 // *
@@ -7278,6 +7416,7 @@ func (x *UpdateArg_Field) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*UpdateArg_Field) ProtoMessage() {}
 
 func (x *UpdateArg_Field) ProtoReflect() protoreflect.Message {
@@ -7339,6 +7478,7 @@ func (x *UrlFilterArg_Url) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*UrlFilterArg_Url) ProtoMessage() {}
 
 func (x *UrlFilterArg_Url) ProtoReflect() protoreflect.Message {
@@ -7395,6 +7535,7 @@ func (x *FlowMeasureReadResponse_Statistic) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*FlowMeasureReadResponse_Statistic) ProtoMessage() {}
 
 func (x *FlowMeasureReadResponse_Statistic) ProtoReflect() protoreflect.Message {
@@ -7481,6 +7622,7 @@ func (x *FlowMeasureReadResponse_Statistic_Histogram) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*FlowMeasureReadResponse_Statistic_Histogram) ProtoMessage() {}
 
 func (x *FlowMeasureReadResponse_Statistic_Histogram) ProtoReflect() protoreflect.Message {
@@ -7578,6 +7720,7 @@ func (x *GtpuPathMonitoringCommandReadResponse_Statistic) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*GtpuPathMonitoringCommandReadResponse_Statistic) ProtoMessage() {}
 
 func (x *GtpuPathMonitoringCommandReadResponse_Statistic) ProtoReflect() protoreflect.Message {
@@ -8083,147 +8226,149 @@ func file_module_msg_proto_rawDescGZIP() []byte {
 	return file_module_msg_proto_rawDescData
 }
 
-var file_module_msg_proto_msgTypes = make([]protoimpl.MessageInfo, 136)
-var file_module_msg_proto_goTypes = []any{
-	(*EmptyArg)(nil),                                        // 0: bess.pb.EmptyArg
-	(*BPFCommandClearArg)(nil),                              // 1: bess.pb.BPFCommandClearArg
-	(*ExactMatchCommandAddArg)(nil),                         // 2: bess.pb.ExactMatchCommandAddArg
-	(*ExactMatchCommandDeleteArg)(nil),                      // 3: bess.pb.ExactMatchCommandDeleteArg
-	(*ExactMatchCommandClearArg)(nil),                       // 4: bess.pb.ExactMatchCommandClearArg
-	(*ExactMatchCommandSetDefaultGateArg)(nil),              // 5: bess.pb.ExactMatchCommandSetDefaultGateArg
-	(*FlowGenCommandSetBurstArg)(nil),                       // 6: bess.pb.FlowGenCommandSetBurstArg
-	(*HashLBCommandSetModeArg)(nil),                         // 7: bess.pb.HashLBCommandSetModeArg
-	(*HashLBCommandSetGatesArg)(nil),                        // 8: bess.pb.HashLBCommandSetGatesArg
-	(*IPLookupCommandAddArg)(nil),                           // 9: bess.pb.IPLookupCommandAddArg
-	(*IPLookupCommandDeleteArg)(nil),                        // 10: bess.pb.IPLookupCommandDeleteArg
-	(*IPLookupCommandClearArg)(nil),                         // 11: bess.pb.IPLookupCommandClearArg
-	(*L2ForwardCommandAddArg)(nil),                          // 12: bess.pb.L2ForwardCommandAddArg
-	(*L2ForwardCommandDeleteArg)(nil),                       // 13: bess.pb.L2ForwardCommandDeleteArg
-	(*L2ForwardCommandSetDefaultGateArg)(nil),               // 14: bess.pb.L2ForwardCommandSetDefaultGateArg
-	(*L2ForwardCommandLookupArg)(nil),                       // 15: bess.pb.L2ForwardCommandLookupArg
-	(*L2ForwardCommandLookupResponse)(nil),                  // 16: bess.pb.L2ForwardCommandLookupResponse
-	(*L2ForwardCommandPopulateArg)(nil),                     // 17: bess.pb.L2ForwardCommandPopulateArg
-	(*MeasureCommandGetSummaryArg)(nil),                     // 18: bess.pb.MeasureCommandGetSummaryArg
-	(*MeasureCommandGetSummaryResponse)(nil),                // 19: bess.pb.MeasureCommandGetSummaryResponse
-	(*DRRArg)(nil),                                          // 20: bess.pb.DRRArg
-	(*DRRQuantumArg)(nil),                                   // 21: bess.pb.DRRQuantumArg
-	(*DRRMaxFlowQueueSizeArg)(nil),                          // 22: bess.pb.DRRMaxFlowQueueSizeArg
-	(*PortIncCommandSetBurstArg)(nil),                       // 23: bess.pb.PortIncCommandSetBurstArg
-	(*QueueIncCommandSetBurstArg)(nil),                      // 24: bess.pb.QueueIncCommandSetBurstArg
-	(*QueueCommandSetBurstArg)(nil),                         // 25: bess.pb.QueueCommandSetBurstArg
-	(*QueueCommandSetSizeArg)(nil),                          // 26: bess.pb.QueueCommandSetSizeArg
-	(*QueueCommandGetStatusArg)(nil),                        // 27: bess.pb.QueueCommandGetStatusArg
-	(*QueueCommandGetStatusResponse)(nil),                   // 28: bess.pb.QueueCommandGetStatusResponse
-	(*RandomUpdateCommandClearArg)(nil),                     // 29: bess.pb.RandomUpdateCommandClearArg
-	(*RewriteCommandClearArg)(nil),                          // 30: bess.pb.RewriteCommandClearArg
-	(*UpdateCommandClearArg)(nil),                           // 31: bess.pb.UpdateCommandClearArg
-	(*WildcardMatchCommandAddArg)(nil),                      // 32: bess.pb.WildcardMatchCommandAddArg
-	(*WildcardMatchCommandDeleteArg)(nil),                   // 33: bess.pb.WildcardMatchCommandDeleteArg
-	(*WildcardMatchCommandClearArg)(nil),                    // 34: bess.pb.WildcardMatchCommandClearArg
-	(*WildcardMatchCommandSetDefaultGateArg)(nil),           // 35: bess.pb.WildcardMatchCommandSetDefaultGateArg
-	(*ACLArg)(nil),                                          // 36: bess.pb.ACLArg
-	(*BPFArg)(nil),                                          // 37: bess.pb.BPFArg
-	(*BufferArg)(nil),                                       // 38: bess.pb.BufferArg
-	(*BypassArg)(nil),                                       // 39: bess.pb.BypassArg
-	(*DumpArg)(nil),                                         // 40: bess.pb.DumpArg
-	(*EtherEncapArg)(nil),                                   // 41: bess.pb.EtherEncapArg
-	(*ExactMatchArg)(nil),                                   // 42: bess.pb.ExactMatchArg
-	(*ExactMatchConfig)(nil),                                // 43: bess.pb.ExactMatchConfig
-	(*FlowGenArg)(nil),                                      // 44: bess.pb.FlowGenArg
-	(*GenericDecapArg)(nil),                                 // 45: bess.pb.GenericDecapArg
-	(*GenericEncapArg)(nil),                                 // 46: bess.pb.GenericEncapArg
-	(*HashLBArg)(nil),                                       // 47: bess.pb.HashLBArg
-	(*IPEncapArg)(nil),                                      // 48: bess.pb.IPEncapArg
-	(*IPLookupArg)(nil),                                     // 49: bess.pb.IPLookupArg
-	(*L2ForwardArg)(nil),                                    // 50: bess.pb.L2ForwardArg
-	(*MACSwapArg)(nil),                                      // 51: bess.pb.MACSwapArg
-	(*MeasureArg)(nil),                                      // 52: bess.pb.MeasureArg
-	(*MergeArg)(nil),                                        // 53: bess.pb.MergeArg
-	(*MetadataTestArg)(nil),                                 // 54: bess.pb.MetadataTestArg
-	(*NATArg)(nil),                                          // 55: bess.pb.NATArg
-	(*StaticNATArg)(nil),                                    // 56: bess.pb.StaticNATArg
-	(*NoOpArg)(nil),                                         // 57: bess.pb.NoOpArg
-	(*PortIncArg)(nil),                                      // 58: bess.pb.PortIncArg
-	(*PortOutArg)(nil),                                      // 59: bess.pb.PortOutArg
-	(*QueueIncArg)(nil),                                     // 60: bess.pb.QueueIncArg
-	(*QueueOutArg)(nil),                                     // 61: bess.pb.QueueOutArg
-	(*QueueArg)(nil),                                        // 62: bess.pb.QueueArg
-	(*RandomSplitArg)(nil),                                  // 63: bess.pb.RandomSplitArg
-	(*RandomSplitCommandSetDroprateArg)(nil),                // 64: bess.pb.RandomSplitCommandSetDroprateArg
-	(*RandomSplitCommandSetGatesArg)(nil),                   // 65: bess.pb.RandomSplitCommandSetGatesArg
-	(*RandomUpdateArg)(nil),                                 // 66: bess.pb.RandomUpdateArg
-	(*RewriteArg)(nil),                                      // 67: bess.pb.RewriteArg
-	(*RoundRobinCommandSetGatesArg)(nil),                    // 68: bess.pb.RoundRobinCommandSetGatesArg
-	(*RoundRobinCommandSetModeArg)(nil),                     // 69: bess.pb.RoundRobinCommandSetModeArg
-	(*RoundRobinArg)(nil),                                   // 70: bess.pb.RoundRobinArg
-	(*ReplicateArg)(nil),                                    // 71: bess.pb.ReplicateArg
-	(*ReplicateCommandSetGatesArg)(nil),                     // 72: bess.pb.ReplicateCommandSetGatesArg
-	(*SetMetadataArg)(nil),                                  // 73: bess.pb.SetMetadataArg
-	(*SinkArg)(nil),                                         // 74: bess.pb.SinkArg
-	(*SourceCommandSetBurstArg)(nil),                        // 75: bess.pb.SourceCommandSetBurstArg
-	(*SourceCommandSetPktSizeArg)(nil),                      // 76: bess.pb.SourceCommandSetPktSizeArg
-	(*SourceArg)(nil),                                       // 77: bess.pb.SourceArg
-	(*IPChecksumArg)(nil),                                   // 78: bess.pb.IPChecksumArg
-	(*L4ChecksumArg)(nil),                                   // 79: bess.pb.L4ChecksumArg
-	(*GtpuEchoArg)(nil),                                     // 80: bess.pb.GtpuEchoArg
-	(*IPDefragArg)(nil),                                     // 81: bess.pb.IPDefragArg
-	(*IPFragArg)(nil),                                       // 82: bess.pb.IPFragArg
-	(*CounterAddArg)(nil),                                   // 83: bess.pb.CounterAddArg
-	(*CounterRemoveArg)(nil),                                // 84: bess.pb.CounterRemoveArg
-	(*CounterArg)(nil),                                      // 85: bess.pb.CounterArg
-	(*GtpuEncapArg)(nil),                                    // 86: bess.pb.GtpuEncapArg
-	(*SplitArg)(nil),                                        // 87: bess.pb.SplitArg
-	(*TimestampArg)(nil),                                    // 88: bess.pb.TimestampArg
-	(*UpdateArg)(nil),                                       // 89: bess.pb.UpdateArg
-	(*UrlFilterArg)(nil),                                    // 90: bess.pb.UrlFilterArg
-	(*UrlFilterConfig)(nil),                                 // 91: bess.pb.UrlFilterConfig
-	(*VLANPopArg)(nil),                                      // 92: bess.pb.VLANPopArg
-	(*VLANPushArg)(nil),                                     // 93: bess.pb.VLANPushArg
-	(*VLANSplitArg)(nil),                                    // 94: bess.pb.VLANSplitArg
-	(*VXLANDecapArg)(nil),                                   // 95: bess.pb.VXLANDecapArg
-	(*VXLANEncapArg)(nil),                                   // 96: bess.pb.VXLANEncapArg
-	(*WildcardMatchArg)(nil),                                // 97: bess.pb.WildcardMatchArg
-	(*WildcardMatchConfig)(nil),                             // 98: bess.pb.WildcardMatchConfig
-	(*ArpResponderArg)(nil),                                 // 99: bess.pb.ArpResponderArg
-	(*MplsPopArg)(nil),                                      // 100: bess.pb.MplsPopArg
-	(*WorkerSplitArg)(nil),                                  // 101: bess.pb.WorkerSplitArg
-	(*QosArg)(nil),                                          // 102: bess.pb.QosArg
-	(*QosCommandAddArg)(nil),                                // 103: bess.pb.QosCommandAddArg
-	(*QosCommandDeleteArg)(nil),                             // 104: bess.pb.QosCommandDeleteArg
-	(*QosCommandClearArg)(nil),                              // 105: bess.pb.QosCommandClearArg
-	(*QosCommandSetDefaultGateArg)(nil),                     // 106: bess.pb.QosCommandSetDefaultGateArg
-	(*FlowMeasureArg)(nil),                                  // 107: bess.pb.FlowMeasureArg
-	(*FlowMeasureCommandReadArg)(nil),                       // 108: bess.pb.FlowMeasureCommandReadArg
-	(*FlowMeasureReadResponse)(nil),                         // 109: bess.pb.FlowMeasureReadResponse
-	(*FlowMeasureCommandFlipArg)(nil),                       // 110: bess.pb.FlowMeasureCommandFlipArg
-	(*FlowMeasureFlipResponse)(nil),                         // 111: bess.pb.FlowMeasureFlipResponse
-	(*GtpuPathMonitoringCommandAddDeleteArg)(nil),           // 112: bess.pb.GtpuPathMonitoringCommandAddDeleteArg
-	(*GtpuPathMonitoringCommandClearArg)(nil),               // 113: bess.pb.GtpuPathMonitoringCommandClearArg
-	(*GtpuPathMonitoringCommandReadArg)(nil),                // 114: bess.pb.GtpuPathMonitoringCommandReadArg
-	(*GtpuPathMonitoringCommandReadResponse)(nil),           // 115: bess.pb.GtpuPathMonitoringCommandReadResponse
-	(*L2ForwardCommandAddArg_Entry)(nil),                    // 116: bess.pb.L2ForwardCommandAddArg.Entry
-	(*MeasureCommandGetSummaryResponse_Histogram)(nil),      // 117: bess.pb.MeasureCommandGetSummaryResponse.Histogram
-	(*ACLArg_Rule)(nil),                                     // 118: bess.pb.ACLArg.Rule
-	(*BPFArg_Filter)(nil),                                   // 119: bess.pb.BPFArg.Filter
-	(*GenericEncapArg_EncapField)(nil),                      // 120: bess.pb.GenericEncapArg.EncapField
-	nil,                                                     // 121: bess.pb.MetadataTestArg.ReadEntry
-	nil,                                                     // 122: bess.pb.MetadataTestArg.WriteEntry
-	nil,                                                     // 123: bess.pb.MetadataTestArg.UpdateEntry
-	(*NATArg_PortRange)(nil),                                // 124: bess.pb.NATArg.PortRange
-	(*NATArg_ExternalAddress)(nil),                          // 125: bess.pb.NATArg.ExternalAddress
-	(*StaticNATArg_AddressRange)(nil),                       // 126: bess.pb.StaticNATArg.AddressRange
-	(*StaticNATArg_AddressRangePair)(nil),                   // 127: bess.pb.StaticNATArg.AddressRangePair
-	(*RandomUpdateArg_Field)(nil),                           // 128: bess.pb.RandomUpdateArg.Field
-	(*SetMetadataArg_Attribute)(nil),                        // 129: bess.pb.SetMetadataArg.Attribute
-	(*UpdateArg_Field)(nil),                                 // 130: bess.pb.UpdateArg.Field
-	(*UrlFilterArg_Url)(nil),                                // 131: bess.pb.UrlFilterArg.Url
-	nil,                                                     // 132: bess.pb.WorkerSplitArg.WorkerGatesEntry
-	(*FlowMeasureReadResponse_Statistic)(nil),               // 133: bess.pb.FlowMeasureReadResponse.Statistic
-	(*FlowMeasureReadResponse_Statistic_Histogram)(nil),     // 134: bess.pb.FlowMeasureReadResponse.Statistic.Histogram
-	(*GtpuPathMonitoringCommandReadResponse_Statistic)(nil), // 135: bess.pb.GtpuPathMonitoringCommandReadResponse.Statistic
-	(*FieldData)(nil),                                       // 136: bess.pb.FieldData
-	(*Field)(nil),                                           // 137: bess.pb.Field
-}
+var (
+	file_module_msg_proto_msgTypes = make([]protoimpl.MessageInfo, 136)
+	file_module_msg_proto_goTypes  = []any{
+		(*EmptyArg)(nil),                                        // 0: bess.pb.EmptyArg
+		(*BPFCommandClearArg)(nil),                              // 1: bess.pb.BPFCommandClearArg
+		(*ExactMatchCommandAddArg)(nil),                         // 2: bess.pb.ExactMatchCommandAddArg
+		(*ExactMatchCommandDeleteArg)(nil),                      // 3: bess.pb.ExactMatchCommandDeleteArg
+		(*ExactMatchCommandClearArg)(nil),                       // 4: bess.pb.ExactMatchCommandClearArg
+		(*ExactMatchCommandSetDefaultGateArg)(nil),              // 5: bess.pb.ExactMatchCommandSetDefaultGateArg
+		(*FlowGenCommandSetBurstArg)(nil),                       // 6: bess.pb.FlowGenCommandSetBurstArg
+		(*HashLBCommandSetModeArg)(nil),                         // 7: bess.pb.HashLBCommandSetModeArg
+		(*HashLBCommandSetGatesArg)(nil),                        // 8: bess.pb.HashLBCommandSetGatesArg
+		(*IPLookupCommandAddArg)(nil),                           // 9: bess.pb.IPLookupCommandAddArg
+		(*IPLookupCommandDeleteArg)(nil),                        // 10: bess.pb.IPLookupCommandDeleteArg
+		(*IPLookupCommandClearArg)(nil),                         // 11: bess.pb.IPLookupCommandClearArg
+		(*L2ForwardCommandAddArg)(nil),                          // 12: bess.pb.L2ForwardCommandAddArg
+		(*L2ForwardCommandDeleteArg)(nil),                       // 13: bess.pb.L2ForwardCommandDeleteArg
+		(*L2ForwardCommandSetDefaultGateArg)(nil),               // 14: bess.pb.L2ForwardCommandSetDefaultGateArg
+		(*L2ForwardCommandLookupArg)(nil),                       // 15: bess.pb.L2ForwardCommandLookupArg
+		(*L2ForwardCommandLookupResponse)(nil),                  // 16: bess.pb.L2ForwardCommandLookupResponse
+		(*L2ForwardCommandPopulateArg)(nil),                     // 17: bess.pb.L2ForwardCommandPopulateArg
+		(*MeasureCommandGetSummaryArg)(nil),                     // 18: bess.pb.MeasureCommandGetSummaryArg
+		(*MeasureCommandGetSummaryResponse)(nil),                // 19: bess.pb.MeasureCommandGetSummaryResponse
+		(*DRRArg)(nil),                                          // 20: bess.pb.DRRArg
+		(*DRRQuantumArg)(nil),                                   // 21: bess.pb.DRRQuantumArg
+		(*DRRMaxFlowQueueSizeArg)(nil),                          // 22: bess.pb.DRRMaxFlowQueueSizeArg
+		(*PortIncCommandSetBurstArg)(nil),                       // 23: bess.pb.PortIncCommandSetBurstArg
+		(*QueueIncCommandSetBurstArg)(nil),                      // 24: bess.pb.QueueIncCommandSetBurstArg
+		(*QueueCommandSetBurstArg)(nil),                         // 25: bess.pb.QueueCommandSetBurstArg
+		(*QueueCommandSetSizeArg)(nil),                          // 26: bess.pb.QueueCommandSetSizeArg
+		(*QueueCommandGetStatusArg)(nil),                        // 27: bess.pb.QueueCommandGetStatusArg
+		(*QueueCommandGetStatusResponse)(nil),                   // 28: bess.pb.QueueCommandGetStatusResponse
+		(*RandomUpdateCommandClearArg)(nil),                     // 29: bess.pb.RandomUpdateCommandClearArg
+		(*RewriteCommandClearArg)(nil),                          // 30: bess.pb.RewriteCommandClearArg
+		(*UpdateCommandClearArg)(nil),                           // 31: bess.pb.UpdateCommandClearArg
+		(*WildcardMatchCommandAddArg)(nil),                      // 32: bess.pb.WildcardMatchCommandAddArg
+		(*WildcardMatchCommandDeleteArg)(nil),                   // 33: bess.pb.WildcardMatchCommandDeleteArg
+		(*WildcardMatchCommandClearArg)(nil),                    // 34: bess.pb.WildcardMatchCommandClearArg
+		(*WildcardMatchCommandSetDefaultGateArg)(nil),           // 35: bess.pb.WildcardMatchCommandSetDefaultGateArg
+		(*ACLArg)(nil),                                          // 36: bess.pb.ACLArg
+		(*BPFArg)(nil),                                          // 37: bess.pb.BPFArg
+		(*BufferArg)(nil),                                       // 38: bess.pb.BufferArg
+		(*BypassArg)(nil),                                       // 39: bess.pb.BypassArg
+		(*DumpArg)(nil),                                         // 40: bess.pb.DumpArg
+		(*EtherEncapArg)(nil),                                   // 41: bess.pb.EtherEncapArg
+		(*ExactMatchArg)(nil),                                   // 42: bess.pb.ExactMatchArg
+		(*ExactMatchConfig)(nil),                                // 43: bess.pb.ExactMatchConfig
+		(*FlowGenArg)(nil),                                      // 44: bess.pb.FlowGenArg
+		(*GenericDecapArg)(nil),                                 // 45: bess.pb.GenericDecapArg
+		(*GenericEncapArg)(nil),                                 // 46: bess.pb.GenericEncapArg
+		(*HashLBArg)(nil),                                       // 47: bess.pb.HashLBArg
+		(*IPEncapArg)(nil),                                      // 48: bess.pb.IPEncapArg
+		(*IPLookupArg)(nil),                                     // 49: bess.pb.IPLookupArg
+		(*L2ForwardArg)(nil),                                    // 50: bess.pb.L2ForwardArg
+		(*MACSwapArg)(nil),                                      // 51: bess.pb.MACSwapArg
+		(*MeasureArg)(nil),                                      // 52: bess.pb.MeasureArg
+		(*MergeArg)(nil),                                        // 53: bess.pb.MergeArg
+		(*MetadataTestArg)(nil),                                 // 54: bess.pb.MetadataTestArg
+		(*NATArg)(nil),                                          // 55: bess.pb.NATArg
+		(*StaticNATArg)(nil),                                    // 56: bess.pb.StaticNATArg
+		(*NoOpArg)(nil),                                         // 57: bess.pb.NoOpArg
+		(*PortIncArg)(nil),                                      // 58: bess.pb.PortIncArg
+		(*PortOutArg)(nil),                                      // 59: bess.pb.PortOutArg
+		(*QueueIncArg)(nil),                                     // 60: bess.pb.QueueIncArg
+		(*QueueOutArg)(nil),                                     // 61: bess.pb.QueueOutArg
+		(*QueueArg)(nil),                                        // 62: bess.pb.QueueArg
+		(*RandomSplitArg)(nil),                                  // 63: bess.pb.RandomSplitArg
+		(*RandomSplitCommandSetDroprateArg)(nil),                // 64: bess.pb.RandomSplitCommandSetDroprateArg
+		(*RandomSplitCommandSetGatesArg)(nil),                   // 65: bess.pb.RandomSplitCommandSetGatesArg
+		(*RandomUpdateArg)(nil),                                 // 66: bess.pb.RandomUpdateArg
+		(*RewriteArg)(nil),                                      // 67: bess.pb.RewriteArg
+		(*RoundRobinCommandSetGatesArg)(nil),                    // 68: bess.pb.RoundRobinCommandSetGatesArg
+		(*RoundRobinCommandSetModeArg)(nil),                     // 69: bess.pb.RoundRobinCommandSetModeArg
+		(*RoundRobinArg)(nil),                                   // 70: bess.pb.RoundRobinArg
+		(*ReplicateArg)(nil),                                    // 71: bess.pb.ReplicateArg
+		(*ReplicateCommandSetGatesArg)(nil),                     // 72: bess.pb.ReplicateCommandSetGatesArg
+		(*SetMetadataArg)(nil),                                  // 73: bess.pb.SetMetadataArg
+		(*SinkArg)(nil),                                         // 74: bess.pb.SinkArg
+		(*SourceCommandSetBurstArg)(nil),                        // 75: bess.pb.SourceCommandSetBurstArg
+		(*SourceCommandSetPktSizeArg)(nil),                      // 76: bess.pb.SourceCommandSetPktSizeArg
+		(*SourceArg)(nil),                                       // 77: bess.pb.SourceArg
+		(*IPChecksumArg)(nil),                                   // 78: bess.pb.IPChecksumArg
+		(*L4ChecksumArg)(nil),                                   // 79: bess.pb.L4ChecksumArg
+		(*GtpuEchoArg)(nil),                                     // 80: bess.pb.GtpuEchoArg
+		(*IPDefragArg)(nil),                                     // 81: bess.pb.IPDefragArg
+		(*IPFragArg)(nil),                                       // 82: bess.pb.IPFragArg
+		(*CounterAddArg)(nil),                                   // 83: bess.pb.CounterAddArg
+		(*CounterRemoveArg)(nil),                                // 84: bess.pb.CounterRemoveArg
+		(*CounterArg)(nil),                                      // 85: bess.pb.CounterArg
+		(*GtpuEncapArg)(nil),                                    // 86: bess.pb.GtpuEncapArg
+		(*SplitArg)(nil),                                        // 87: bess.pb.SplitArg
+		(*TimestampArg)(nil),                                    // 88: bess.pb.TimestampArg
+		(*UpdateArg)(nil),                                       // 89: bess.pb.UpdateArg
+		(*UrlFilterArg)(nil),                                    // 90: bess.pb.UrlFilterArg
+		(*UrlFilterConfig)(nil),                                 // 91: bess.pb.UrlFilterConfig
+		(*VLANPopArg)(nil),                                      // 92: bess.pb.VLANPopArg
+		(*VLANPushArg)(nil),                                     // 93: bess.pb.VLANPushArg
+		(*VLANSplitArg)(nil),                                    // 94: bess.pb.VLANSplitArg
+		(*VXLANDecapArg)(nil),                                   // 95: bess.pb.VXLANDecapArg
+		(*VXLANEncapArg)(nil),                                   // 96: bess.pb.VXLANEncapArg
+		(*WildcardMatchArg)(nil),                                // 97: bess.pb.WildcardMatchArg
+		(*WildcardMatchConfig)(nil),                             // 98: bess.pb.WildcardMatchConfig
+		(*ArpResponderArg)(nil),                                 // 99: bess.pb.ArpResponderArg
+		(*MplsPopArg)(nil),                                      // 100: bess.pb.MplsPopArg
+		(*WorkerSplitArg)(nil),                                  // 101: bess.pb.WorkerSplitArg
+		(*QosArg)(nil),                                          // 102: bess.pb.QosArg
+		(*QosCommandAddArg)(nil),                                // 103: bess.pb.QosCommandAddArg
+		(*QosCommandDeleteArg)(nil),                             // 104: bess.pb.QosCommandDeleteArg
+		(*QosCommandClearArg)(nil),                              // 105: bess.pb.QosCommandClearArg
+		(*QosCommandSetDefaultGateArg)(nil),                     // 106: bess.pb.QosCommandSetDefaultGateArg
+		(*FlowMeasureArg)(nil),                                  // 107: bess.pb.FlowMeasureArg
+		(*FlowMeasureCommandReadArg)(nil),                       // 108: bess.pb.FlowMeasureCommandReadArg
+		(*FlowMeasureReadResponse)(nil),                         // 109: bess.pb.FlowMeasureReadResponse
+		(*FlowMeasureCommandFlipArg)(nil),                       // 110: bess.pb.FlowMeasureCommandFlipArg
+		(*FlowMeasureFlipResponse)(nil),                         // 111: bess.pb.FlowMeasureFlipResponse
+		(*GtpuPathMonitoringCommandAddDeleteArg)(nil),           // 112: bess.pb.GtpuPathMonitoringCommandAddDeleteArg
+		(*GtpuPathMonitoringCommandClearArg)(nil),               // 113: bess.pb.GtpuPathMonitoringCommandClearArg
+		(*GtpuPathMonitoringCommandReadArg)(nil),                // 114: bess.pb.GtpuPathMonitoringCommandReadArg
+		(*GtpuPathMonitoringCommandReadResponse)(nil),           // 115: bess.pb.GtpuPathMonitoringCommandReadResponse
+		(*L2ForwardCommandAddArg_Entry)(nil),                    // 116: bess.pb.L2ForwardCommandAddArg.Entry
+		(*MeasureCommandGetSummaryResponse_Histogram)(nil),      // 117: bess.pb.MeasureCommandGetSummaryResponse.Histogram
+		(*ACLArg_Rule)(nil),                                     // 118: bess.pb.ACLArg.Rule
+		(*BPFArg_Filter)(nil),                                   // 119: bess.pb.BPFArg.Filter
+		(*GenericEncapArg_EncapField)(nil),                      // 120: bess.pb.GenericEncapArg.EncapField
+		nil,                                                     // 121: bess.pb.MetadataTestArg.ReadEntry
+		nil,                                                     // 122: bess.pb.MetadataTestArg.WriteEntry
+		nil,                                                     // 123: bess.pb.MetadataTestArg.UpdateEntry
+		(*NATArg_PortRange)(nil),                                // 124: bess.pb.NATArg.PortRange
+		(*NATArg_ExternalAddress)(nil),                          // 125: bess.pb.NATArg.ExternalAddress
+		(*StaticNATArg_AddressRange)(nil),                       // 126: bess.pb.StaticNATArg.AddressRange
+		(*StaticNATArg_AddressRangePair)(nil),                   // 127: bess.pb.StaticNATArg.AddressRangePair
+		(*RandomUpdateArg_Field)(nil),                           // 128: bess.pb.RandomUpdateArg.Field
+		(*SetMetadataArg_Attribute)(nil),                        // 129: bess.pb.SetMetadataArg.Attribute
+		(*UpdateArg_Field)(nil),                                 // 130: bess.pb.UpdateArg.Field
+		(*UrlFilterArg_Url)(nil),                                // 131: bess.pb.UrlFilterArg.Url
+		nil,                                                     // 132: bess.pb.WorkerSplitArg.WorkerGatesEntry
+		(*FlowMeasureReadResponse_Statistic)(nil),               // 133: bess.pb.FlowMeasureReadResponse.Statistic
+		(*FlowMeasureReadResponse_Statistic_Histogram)(nil),     // 134: bess.pb.FlowMeasureReadResponse.Statistic.Histogram
+		(*GtpuPathMonitoringCommandReadResponse_Statistic)(nil), // 135: bess.pb.GtpuPathMonitoringCommandReadResponse.Statistic
+		(*FieldData)(nil),                                       // 136: bess.pb.FieldData
+		(*Field)(nil),                                           // 137: bess.pb.Field
+	}
+)
 var file_module_msg_proto_depIdxs = []int32{
 	136, // 0: bess.pb.ExactMatchCommandAddArg.fields:type_name -> bess.pb.FieldData
 	136, // 1: bess.pb.ExactMatchCommandAddArg.values:type_name -> bess.pb.FieldData

--- a/pfcpiface/bess_pb/ports/port_msg.pb.go
+++ b/pfcpiface/bess_pb/ports/port_msg.pb.go
@@ -72,6 +72,7 @@ func (x *PCAPPortArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*PCAPPortArg) ProtoMessage() {}
 
 func (x *PCAPPortArg) ProtoReflect() protoreflect.Message {
@@ -135,6 +136,7 @@ func (x *PMDPortArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*PMDPortArg) ProtoMessage() {}
 
 func (x *PMDPortArg) ProtoReflect() protoreflect.Message {
@@ -269,10 +271,13 @@ type PMDPortArg_Vdev struct {
 	Vdev string `protobuf:"bytes,4,opt,name=vdev,proto3,oneof"`
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*PMDPortArg_PortId) isPMDPortArg_Port() {}
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*PMDPortArg_Pci) isPMDPortArg_Port() {}
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*PMDPortArg_Vdev) isPMDPortArg_Port() {}
 
 type isPMDPortArg_Socket interface {
@@ -283,6 +288,7 @@ type PMDPortArg_SocketId struct {
 	SocketId int32 `protobuf:"varint,8,opt,name=socket_id,json=socketId,proto3,oneof"`
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*PMDPortArg_SocketId) isPMDPortArg_Socket() {}
 
 type UnixSocketPortArg struct {
@@ -313,6 +319,7 @@ func (x *UnixSocketPortArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*UnixSocketPortArg) ProtoMessage() {}
 
 func (x *UnixSocketPortArg) ProtoReflect() protoreflect.Message {
@@ -382,6 +389,7 @@ func (x *VPortArg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*VPortArg) ProtoMessage() {}
 
 func (x *VPortArg) ProtoReflect() protoreflect.Message {
@@ -493,10 +501,13 @@ type VPortArg_Netns struct {
 	Netns string `protobuf:"bytes,4,opt,name=netns,proto3,oneof"`
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*VPortArg_Docker) isVPortArg_Cpid() {}
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*VPortArg_ContainerPid) isVPortArg_Cpid() {}
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*VPortArg_Netns) isVPortArg_Cpid() {}
 
 var File_ports_port_msg_proto protoreflect.FileDescriptor
@@ -551,13 +562,15 @@ func file_ports_port_msg_proto_rawDescGZIP() []byte {
 	return file_ports_port_msg_proto_rawDescData
 }
 
-var file_ports_port_msg_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
-var file_ports_port_msg_proto_goTypes = []any{
-	(*PCAPPortArg)(nil),       // 0: bess.pb.PCAPPortArg
-	(*PMDPortArg)(nil),        // 1: bess.pb.PMDPortArg
-	(*UnixSocketPortArg)(nil), // 2: bess.pb.UnixSocketPortArg
-	(*VPortArg)(nil),          // 3: bess.pb.VPortArg
-}
+var (
+	file_ports_port_msg_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+	file_ports_port_msg_proto_goTypes  = []any{
+		(*PCAPPortArg)(nil),       // 0: bess.pb.PCAPPortArg
+		(*PMDPortArg)(nil),        // 1: bess.pb.PMDPortArg
+		(*UnixSocketPortArg)(nil), // 2: bess.pb.UnixSocketPortArg
+		(*VPortArg)(nil),          // 3: bess.pb.VPortArg
+	}
+)
 var file_ports_port_msg_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/pfcpiface/bess_pb/util_msg.pb.go
+++ b/pfcpiface/bess_pb/util_msg.pb.go
@@ -78,6 +78,7 @@ func (x *Field) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*Field) ProtoMessage() {}
 
 func (x *Field) ProtoReflect() protoreflect.Message {
@@ -141,8 +142,10 @@ type Field_Offset struct {
 	Offset uint32 `protobuf:"varint,2,opt,name=offset,proto3,oneof"` /// The offset in bytes to store the data into
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*Field_AttrName) isField_Position() {}
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*Field_Offset) isField_Position() {}
 
 // / The FieldData message encodes a value to insert into a packet; the value can
@@ -169,6 +172,7 @@ func (x *FieldData) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*FieldData) ProtoMessage() {}
 
 func (x *FieldData) ProtoReflect() protoreflect.Message {
@@ -225,8 +229,10 @@ type FieldData_ValueInt struct {
 	ValueInt uint64 `protobuf:"varint,2,opt,name=value_int,json=valueInt,proto3,oneof"` /// The value in integer format
 }
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*FieldData_ValueBin) isFieldData_Encoding() {}
 
+// SONARQB: Empty protobuf generated method is safe to ignore
 func (*FieldData_ValueInt) isFieldData_Encoding() {}
 
 var File_util_msg_proto protoreflect.FileDescriptor
@@ -258,11 +264,13 @@ func file_util_msg_proto_rawDescGZIP() []byte {
 	return file_util_msg_proto_rawDescData
 }
 
-var file_util_msg_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-var file_util_msg_proto_goTypes = []any{
-	(*Field)(nil),     // 0: bess.pb.Field
-	(*FieldData)(nil), // 1: bess.pb.FieldData
-}
+var (
+	file_util_msg_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+	file_util_msg_proto_goTypes  = []any{
+		(*Field)(nil),     // 0: bess.pb.Field
+		(*FieldData)(nil), // 1: bess.pb.FieldData
+	}
+)
 var file_util_msg_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/pfcpiface/tools/fix_sonar_pb.go
+++ b/pfcpiface/tools/fix_sonar_pb.go
@@ -32,17 +32,14 @@ func main() {
 	if len(os.Args) > 1 {
 		root = os.Args[1]
 	}
-
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-
 		if strings.HasSuffix(path, ".pb.go") {
 			fmt.Println("Processing:", path)
 			return processFile(path)
 		}
-
 		return nil
 	})
 	if err != nil {
@@ -56,21 +53,17 @@ func processFile(path string) error {
 	if err != nil {
 		return err
 	}
-
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
-
 	original := string(data)
 	lines := strings.Split(original, "\n")
 	output := make([]string, 0, len(lines)+8)
 	modified := false
-
 	for i := 0; i < len(lines); i++ {
 		line := lines[i]
 		trim := strings.TrimSpace(line)
-
 		// Match any empty function: func (...) methodName() {}
 		if strings.HasPrefix(trim, "func (") && strings.HasSuffix(trim, "{}") {
 			methodName := extractMethodName(trim)
@@ -86,14 +79,11 @@ func processFile(path string) error {
 				modified = true
 			}
 		}
-
 		output = append(output, line)
 	}
-
 	if !modified {
 		return nil
 	}
-
 	return os.WriteFile(path, []byte(strings.Join(output, "\n")), fi.Mode().Perm())
 }
 
@@ -102,7 +92,6 @@ func extractMethodName(line string) string {
 	// Example:
 	// func (*Type) ProtoMessage() {}
 	// func (*Type) isSomething() {}
-
 	parts := strings.Split(line, ")")
 	if len(parts) < 2 {
 		return ""

--- a/pfcpiface/tools/fix_sonar_pb.go
+++ b/pfcpiface/tools/fix_sonar_pb.go
@@ -29,6 +29,10 @@ var targetMethods = map[string]bool{
 
 func main() {
 	root := "pfcpiface/bess_pb"
+	if len(os.Args) > 1 {
+		root = os.Args[1]
+	}
+
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -48,17 +52,25 @@ func main() {
 }
 
 func processFile(path string) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 
-	lines := strings.Split(string(data), "\n")
-	var output []string
+	original := string(data)
+	lines := strings.Split(original, "\n")
+	output := make([]string, 0, len(lines)+8)
+	modified := false
 
 	for i := 0; i < len(lines); i++ {
 		line := lines[i]
 		trim := strings.TrimSpace(line)
+
 		// Match any empty function: func (...) methodName() {}
 		if strings.HasPrefix(trim, "func (") && strings.HasSuffix(trim, "{}") {
 			methodName := extractMethodName(trim)
@@ -68,13 +80,21 @@ func processFile(path string) error {
 					output = append(output, line)
 					continue
 				}
+
 				fmt.Println("Adding comment above:", methodName)
 				output = append(output, "// SONARQB: Empty protobuf generated method is safe to ignore")
+				modified = true
 			}
 		}
+
 		output = append(output, line)
 	}
-	return os.WriteFile(path, []byte(strings.Join(output, "\n")), 0o644)
+
+	if !modified {
+		return nil
+	}
+
+	return os.WriteFile(path, []byte(strings.Join(output, "\n")), fi.Mode().Perm())
 }
 
 // Extract method name from line

--- a/pfcpiface/tools/fix_sonar_pb.go
+++ b/pfcpiface/tools/fix_sonar_pb.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020-present Open Networking Foundation
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// List of methods to target
+var targetMethods = map[string]bool{
+	"ProtoMessage":                           true,
+	"isTrafficClass_Arg":                     true,
+	"isGateHookInfo_Gate":                    true,
+	"isMeasureArg_Type":                      true,
+	"isSplitArg_Type":                        true,
+	"isTimestampArg_Type":                    true,
+	"isQosCommandAddArg_OptionalDeductLen":   true,
+	"isGenericEncapArg_EncapField_Insertion": true,
+	"isSetMetadataArg_Attribute_Value":       true,
+	"isPMDPortArg_Port":                      true,
+	"isPMDPortArg_Socket":                    true,
+	"isVPortArg_Cpid":                        true,
+	"isField_Position":                       true,
+	"isFieldData_Encoding":                   true,
+}
+
+func main() {
+	root := "pfcpiface/bess_pb"
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if strings.HasSuffix(path, ".pb.go") {
+			fmt.Println("Processing:", path)
+			return processFile(path)
+		}
+
+		return nil
+	})
+	if err != nil {
+		fmt.Println("Error:", err)
+		os.Exit(1)
+	}
+}
+
+func processFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var output []string
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		trim := strings.TrimSpace(line)
+		// Match any empty function: func (...) methodName() {}
+		if strings.HasPrefix(trim, "func (") && strings.HasSuffix(trim, "{}") {
+			methodName := extractMethodName(trim)
+			if targetMethods[methodName] {
+				// Skip if already has SONARQB
+				if i > 0 && strings.Contains(lines[i-1], "SONARQB") {
+					output = append(output, line)
+					continue
+				}
+				fmt.Println("Adding comment above:", methodName)
+				output = append(output, "// SONARQB: Empty protobuf generated method is safe to ignore")
+			}
+		}
+		output = append(output, line)
+	}
+	return os.WriteFile(path, []byte(strings.Join(output, "\n")), 0o644)
+}
+
+// Extract method name from line
+func extractMethodName(line string) string {
+	// Example:
+	// func (*Type) ProtoMessage() {}
+	// func (*Type) isSomething() {}
+
+	parts := strings.Split(line, ")")
+	if len(parts) < 2 {
+		return ""
+	}
+	right := strings.TrimSpace(parts[1]) // ProtoMessage() {}
+	name := strings.Split(right, "(")[0]
+	return strings.TrimSpace(name)
+}

--- a/pfcpiface/tools/fix_sonar_pb.go
+++ b/pfcpiface/tools/fix_sonar_pb.go
@@ -61,7 +61,7 @@ func processFile(path string) error {
 	lines := strings.Split(original, "\n")
 	output := make([]string, 0, len(lines)+8)
 	modified := false
-	for i := 0; i < len(lines); i++ {
+	for i := range lines {
 		line := lines[i]
 		trim := strings.TrimSpace(line)
 		// Match any empty function: func (...) methodName() {}


### PR DESCRIPTION
This PR addresses SonarQube issues reported in autogenerated protobuf Go files (.pb.go) where empty stub functions do not contain proper nested comments explaining why the functions are intentionally empty. These issues affect static analysis and code quality checks during CI/CD execution.

To handle this consistently for regenerated protobuf files, a post-generation script has been added to automatically insert the required comments into targeted autogenerated empty methods after protobuf generation.