### PR TITLE
fix(pfcpiface): complete the gRPC batch before reporting its result

### DIFF
--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -1550,8 +1550,8 @@ func (b *bess) delSessionQER(ctx context.Context, srcIface uint8, qer qer) {
 	}
 }
 
-// GRPCJoin waits for calls asynchronous operations, each of which reports exactly one
-// result on done, and reports whether all of them succeeded.
+// GRPCJoin waits for the given number of asynchronous operations, each of which reports
+// exactly one result on done, and reports whether all of them succeeded.
 //
 // It waits for every operation to report rather than returning as soon as one fails.
 // The callers use the result to decide what the datapath now holds, and an operation

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -119,7 +119,7 @@ func (b *bess) AddSliceInfo(sliceInfo *SliceInfo) error {
 	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
 	defer cancel()
 
-	done := make(chan bool)
+	done := make(chan bool, 1)
 
 	b.addSliceMeter(ctx, done, sliceMeterConfig)
 
@@ -156,7 +156,7 @@ func (b *bess) SendMsgToUPF(
 	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
 	defer cancel()
 
-	done := make(chan bool)
+	done := make(chan bool, calls)
 
 	for _, pdr := range pdrs {
 		logger.BessLog.Debugln(method, pdr)
@@ -843,7 +843,7 @@ func (b *bess) SetUpfInfo(u *upf, conf *Conf) {
 		ctx, cancel := context.WithTimeout(context.Background(), Timeout)
 		defer cancel()
 
-		done := make(chan bool)
+		done := make(chan bool, 1)
 
 		b.addSliceMeter(ctx, done, conf.SliceMeterConfig)
 
@@ -881,6 +881,9 @@ func (b *bess) processPDR(ctx context.Context, arg *anypb.Any, method upfMsgType
 
 func (b *bess) addPDR(ctx context.Context, done chan<- bool, p pdr) {
 	go func() {
+		completed := false
+		defer func() { done <- completed }()
+
 		var (
 			arg *anypb.Any
 			err error
@@ -943,12 +946,15 @@ func (b *bess) addPDR(ctx context.Context, done chan<- bool, p pdr) {
 
 			b.processPDR(ctx, arg, upfMsgTypeAdd)
 		}
-		done <- true
+		completed = true
 	}()
 }
 
 func (b *bess) delPDR(ctx context.Context, done chan<- bool, p pdr) {
 	go func() {
+		completed := false
+		defer func() { done <- completed }()
+
 		var (
 			arg *anypb.Any
 			err error
@@ -993,12 +999,15 @@ func (b *bess) delPDR(ctx context.Context, done chan<- bool, p pdr) {
 
 			b.processPDR(ctx, arg, upfMsgTypeDel)
 		}
-		done <- true
+		completed = true
 	}()
 }
 
 func (b *bess) addQER(ctx context.Context, done chan<- bool, qer qer) {
 	go func() {
+		completed := false
+		defer func() { done <- completed }()
+
 		var (
 			cir, pir, cbs, ebs, pbs, gate uint64
 			srcIface                      uint8
@@ -1072,7 +1081,7 @@ func (b *bess) addQER(ctx context.Context, done chan<- bool, qer qer) {
 			b.addSessionQER(ctx, gate, srcIface, cir, pir, cbs, pbs, ebs, qer)
 		}
 
-		done <- true
+		completed = true
 	}()
 }
 
@@ -1118,6 +1127,9 @@ func (b *bess) addApplicationQER(ctx context.Context, gate uint64, srcIface uint
 
 func (b *bess) delQER(ctx context.Context, done chan<- bool, qer qer) {
 	go func() {
+		completed := false
+		defer func() { done <- completed }()
+
 		var srcIface uint8
 
 		// Uplink QER
@@ -1140,7 +1152,7 @@ func (b *bess) delQER(ctx context.Context, done chan<- bool, qer qer) {
 			b.delSessionQER(ctx, srcIface, qer)
 		}
 
-		done <- true
+		completed = true
 	}()
 }
 
@@ -1238,6 +1250,9 @@ func (b *bess) setActionValue(f far) uint8 {
 
 func (b *bess) addFAR(ctx context.Context, done chan<- bool, far far) {
 	go func() {
+		completed := false
+		defer func() { done <- completed }()
+
 		var (
 			arg *anypb.Any
 			err error
@@ -1282,12 +1297,15 @@ func (b *bess) addFAR(ctx context.Context, done chan<- bool, far far) {
 			b.processGtpuPathMonitoring(ctx, arg, upfMsgTypeAdd)
 		}
 
-		done <- true
+		completed = true
 	}()
 }
 
 func (b *bess) delFAR(ctx context.Context, done chan<- bool, far far) {
 	go func() {
+		completed := false
+		defer func() { done <- completed }()
+
 		var (
 			arg *anypb.Any
 			err error
@@ -1322,7 +1340,7 @@ func (b *bess) delFAR(ctx context.Context, done chan<- bool, far far) {
 			b.processGtpuPathMonitoring(ctx, arg, upfMsgTypeDel)
 		}
 
-		done <- true
+		completed = true
 	}()
 }
 
@@ -1348,6 +1366,9 @@ func (b *bess) processSliceMeter(ctx context.Context, arg *anypb.Any, method upf
 
 func (b *bess) addSliceMeter(ctx context.Context, done chan<- bool, meterConfig SliceMeterConfig) {
 	go func() {
+		completed := false
+		defer func() { done <- completed }()
+
 		var (
 			arg                           *anypb.Any
 			err                           error
@@ -1439,7 +1460,7 @@ func (b *bess) addSliceMeter(ctx context.Context, done chan<- bool, meterConfig 
 		}
 
 		b.processSliceMeter(ctx, arg, upfMsgTypeAdd)
-		done <- true
+		completed = true
 	}()
 }
 
@@ -1529,24 +1550,34 @@ func (b *bess) delSessionQER(ctx context.Context, srcIface uint8, qer qer) {
 	}
 }
 
+// GRPCJoin waits for calls asynchronous operations, each of which reports exactly one
+// result on done, and reports whether all of them succeeded.
+//
+// It waits for every operation to report rather than returning as soon as one fails.
+// The callers use the result to decide what the datapath now holds, and an operation
+// still in flight when the caller has moved on can be overtaken by a later one that
+// touches the same rule — leaving the datapath holding a rule the caller believes it
+// has already replaced. A failing batch therefore costs up to the full timeout instead
+// of returning at the first failure, which the timeout already bounds.
 func (b *bess) GRPCJoin(calls int, timeout time.Duration, done chan bool) bool {
 	boom := time.After(timeout)
+	succeeded := true
 
-	for {
+	for calls > 0 {
 		select {
 		case ok := <-done:
 			if !ok {
 				logger.BessLog.Errorln("error making GRPC calls")
-				return false
+
+				succeeded = false
 			}
 
 			calls--
-			if calls == 0 {
-				return true
-			}
 		case <-boom:
 			logger.BessLog.Infoln("timed out adding entries")
 			return false
 		}
 	}
+
+	return succeeded
 }

--- a/pfcpiface/bess_test.go
+++ b/pfcpiface/bess_test.go
@@ -23,7 +23,7 @@ func TestGRPCJoinWaitsForEveryCallBeforeReturning(t *testing.T) {
 	var reported atomic.Int32
 
 	// The failure is reported first and the successes arrive later. A join that returns
-	// on the first failure leaves the remaining senders blocked for ever on a channel
+	// on the first failure leaves the remaining senders blocked forever on a channel
 	// nobody will read again, and returns while their writes are still in flight.
 	go func() {
 		reported.Add(1)

--- a/pfcpiface/bess_test.go
+++ b/pfcpiface/bess_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Open Networking Foundation
+
+package pfcpiface
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The channel these tests pass to GRPCJoin is deliberately unbuffered, because that is
+// what SendMsgToUPF allocated before this fix: it is the shape in which a stranded
+// sender is observable.
+
+func TestGRPCJoinWaitsForEveryCallBeforeReturning(t *testing.T) {
+	b := &bess{}
+
+	const calls = 4
+
+	done := make(chan bool)
+
+	var reported atomic.Int32
+
+	// The failure is reported first and the successes arrive later. A join that returns
+	// on the first failure leaves the remaining senders blocked for ever on a channel
+	// nobody will read again, and returns while their writes are still in flight.
+	go func() {
+		reported.Add(1)
+		done <- false
+	}()
+
+	for i := 1; i < calls; i++ {
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			reported.Add(1)
+			done <- true
+		}()
+	}
+
+	if b.GRPCJoin(calls, time.Second, done) {
+		t.Error("GRPCJoin reported success for a batch containing a failed call")
+	}
+
+	if got := reported.Load(); got != calls {
+		t.Errorf("GRPCJoin returned with %d of %d calls still in flight; every call must have reported",
+			calls-int(got), calls)
+	}
+}
+
+func TestGRPCJoinReportsSuccessWhenEveryCallSucceeds(t *testing.T) {
+	b := &bess{}
+
+	const calls = 3
+
+	done := make(chan bool)
+
+	for i := 0; i < calls; i++ {
+		go func() { done <- true }()
+	}
+
+	if !b.GRPCJoin(calls, time.Second, done) {
+		t.Error("GRPCJoin reported failure for a batch in which every call succeeded")
+	}
+}
+
+func TestGRPCJoinReportsFailureWhenAnyCallFails(t *testing.T) {
+	b := &bess{}
+
+	const calls = 3
+
+	done := make(chan bool)
+
+	// The failure is reported last, so it cannot be found by returning early.
+	for i := 0; i < calls-1; i++ {
+		go func() { done <- true }()
+	}
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		done <- false
+	}()
+
+	if b.GRPCJoin(calls, time.Second, done) {
+		t.Error("GRPCJoin reported success for a batch whose last call failed")
+	}
+}
+
+func TestGRPCJoinReturnsWhenACallNeverReports(t *testing.T) {
+	b := &bess{}
+
+	done := make(chan bool)
+
+	go func() { done <- true }()
+
+	start := time.Now()
+
+	if b.GRPCJoin(2, 50*time.Millisecond, done) {
+		t.Error("GRPCJoin reported success for a batch one of whose calls never reported")
+	}
+
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("GRPCJoin took %v to give up; the deadline must bound it", elapsed)
+	}
+}
+
+// A rule the worker abandons before reaching the datapath must still report a result.
+// Where it reports nothing, the join can never account for it: the batch consumes its
+// whole deadline and only then reports a failure whose cause is already known.
+func TestAPDRThatCannotBeExpandedStillReportsItsResult(t *testing.T) {
+	b := &bess{}
+
+	done := make(chan bool, 1)
+
+	// Both ports as range matches is refused by CreatePortRangeCartesianProduct, so
+	// addPDR returns before it uses the datapath client at all.
+	p := pdr{}
+	p.appFilter.srcPortRange = newRangeMatchPortRange(100, 200)
+	p.appFilter.dstPortRange = newRangeMatchPortRange(300, 400)
+
+	b.addPDR(t.Context(), done, p)
+
+	select {
+	case ok := <-done:
+		if ok {
+			t.Error("a PDR that was never programmed was reported as done")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("addPDR reported nothing for a rule it abandoned; the batch cannot complete")
+	}
+}


### PR DESCRIPTION
## What

`SendMsgToUPF` programs a PFCP session's rules as a batch of concurrent gRPC calls and joins them with `GRPCJoin`. The join and its workers disagree about how many results there will be, in three ways. Each of them strands goroutines, and the third can leave the datapath holding a rule the caller believes it has already replaced.

## The defects

**1. A join that returns early strands every worker still running.**

`GRPCJoin` returns on the first `false` it reads and on its deadline. `done` is unbuffered and every worker ends with an unconditional send. So when the join returns early, each worker still running blocks for ever on a send nobody will read. Cancelling the context does not free them — they are blocked on the channel, not on the RPC.

Each stranded goroutine pins its rule, its marshalled `Any` and its context. The leak is permanent and cumulative for the life of the process. The reachable trigger today is the deadline: it covers the whole PDR + FAR + QER fan-out, so it fires whenever the *slowest* write in a batch exceeds it, which says nothing about the others.

**2. Five of the seven workers can return without reporting at all.**

`addPDR`, `delPDR`, `addFAR`, `delFAR` and `addSliceMeter` each have paths that `return` before their `done <- true` — an unexpandable port range, a rule that fails to marshal. `calls` can then never reach zero, so the batch always consumes its whole deadline and only then reports a failure whose cause was known before it started.

**3. The join can return while writes are still in flight.**

Because of (1), `SendMsgToUPF` can return before its own writes have landed. A later batch touching the same rule can be overtaken by an earlier one, leaving the datapath holding a rule the caller believes it has already replaced. Every caller reads the result as "the datapath is now in this state"; today it does not mean that.

## The fix

- Each worker reports exactly one result, via `defer`, so a worker that abandons a rule cannot make its batch un-completable — and a future edit that adds an early return cannot reintroduce this.
- `done` is buffered for the whole batch, so no worker can block on a send.
- `GRPCJoin` accounts for every call before returning.

The return value keeps its meaning for every caller — false if anything failed — and gains the property they all already assume: the writes are done.

## Behaviour change

A failing batch now costs up to the full `Timeout` (1 s) instead of returning at the first failure. The deadline already bounds that, and a caller acting on a wrong picture of the datapath is worse than one acting later. Nothing else changes: the success path makes the same calls and returns the same result, and `SendMsgToUPF` still returns `CauseRequestAccepted` as before.

## Tests

New `pfcpiface/bess_test.go`. Two of the five fail against `main`, naming the harm:

```
--- FAIL: TestGRPCJoinWaitsForEveryCallBeforeReturning
    GRPCJoin returned with 3 of 4 calls still in flight; every call must have reported
--- FAIL: TestAPDRThatCannotBeExpandedStillReportsItsResult  (2.00s)
    addPDR reported nothing for a rule it abandoned; the batch cannot complete
```

The second consumes its whole deadline before failing, which is defect (2) directly. The other three tests pin the semantics that must not change — success, failure, and the deadline — and pass both before and after.

`go build ./...`, `go test ./... -race` and `golangci-lint run pfcpiface/...` are clean. `test/integration` does not run on macOS (it binds `127.0.0.8`), and fails identically on unmodified `main` here.

## Note for reviewers

There is a follow-up worth making separately: `rc` is logged and discarded at all three `GRPCJoin` call sites, and `SendMsgToUPF` returns `ie.CauseRequestAccepted` unconditionally — so a session whose rules never reached BESS is answered to the SMF as established. That is a visible behaviour change and deserves its own PR.

**It should not land before this one.** Making the workers report their real outcome is what makes `GRPCJoin`'s first-`false` return reachable; today it is dead code because every send is `done <- true`. We made that change first on a downstream branch, and a batch could then report *refused* having already programmed an unknown subset of its rules, with the caller recording nothing. It took a while to trace. This PR is the half that makes the other half safe.