### PR TITLE
pfcpiface: keep the downlink notification path alive, and make it visible

### DIFF
--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"net"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/omec-project/upf-epc/logger"
@@ -28,6 +29,9 @@ const (
 	DefaultBurstSize = 32 * 1514
 	// SockAddr : Unix Socket path to read bess notification from.
 	SockAddr = "/tmp/notifycp"
+	// notifyRedialInterval is how long to wait before reconnecting to the
+	// datapath's notification socket after a dial or read failure.
+	notifyRedialInterval = 2 * time.Second
 	// PfcpAddr : Unix Socket path to send end marker packet.
 	PfcpAddr = "/tmp/pfcpport"
 	// AppQerLookup: Application Qos table Name.
@@ -85,12 +89,14 @@ var bessIP = flag.String("bess", "localhost:10514", "BESS IP/port combo")
 var enableGtpuPathMonitoring = false
 
 type bess struct {
-	client           pb.BESSControlClient
-	conn             *grpc.ClientConn
-	endMarkerSocket  net.Conn
-	notifyBessSocket net.Conn
-	endMarkerChan    chan []byte
-	qciQosMap        map[uint8]*QosConfigVal
+	client          pb.BESSControlClient
+	conn            *grpc.ClientConn
+	endMarkerSocket net.Conn
+	notifyStop      chan struct{}
+	notifyMu        sync.Mutex
+	notifyConn      net.Conn
+	endMarkerChan   chan []byte
+	qciQosMap       map[uint8]*QosConfigVal
 }
 
 func (b *bess) IsConnected(accessIP *net.IP) bool {
@@ -207,6 +213,15 @@ func (b *bess) SendMsgToUPF(
 
 func (b *bess) Exit() {
 	logger.BessLog.Infoln("exit function Bess")
+
+	if b.notifyStop != nil {
+		close(b.notifyStop)
+		// Closing the channel alone cannot end a read that is already blocked, so
+		// close the socket too: without this the listener stays parked until the
+		// datapath happens to disconnect.
+		b.closeNotifyConn()
+	}
+
 	b.conn.Close()
 }
 
@@ -676,21 +691,123 @@ func (b *bess) endMarkerSendLoop(endMarkerChan chan []byte) {
 	}
 }
 
-func (b *bess) notifyListen(reportNotifyChan chan<- uint64) {
+// notifyListen owns the connection to the datapath's control-plane notification
+// socket for the life of the process. Every downlink-data notification for a
+// buffering session arrives here, so losing this loop means no Session Report
+// reaches the SMF, no paging is triggered, and an idle UE becomes unreachable.
+//
+// It used to return on the first read error -- no log line, no reconnect -- so a
+// single transient failure disabled mobile-terminated reachability until the pod
+// was restarted, and nothing said so: the datapath kept writing notifications
+// into a socket with no reader, reporting successful transmits.
+func (b *bess) notifyListen(reportNotifyChan chan<- uint64, notifySockAddr string) {
+	// The rate limiter outlives reconnects on purpose: reconnecting is not a
+	// reason to re-notify for a session reported moments ago.
 	notifier := NewDownlinkDataNotifier(reportNotifyChan, 20*time.Second)
 
-	for {
-		buf := make([]byte, 512)
+	logger.BessLog.Infoln("downlink data notification listener started, socket:", notifySockAddr)
 
-		_, err := b.notifyBessSocket.Read(buf)
+	for {
+		select {
+		case <-b.notifyStop:
+			logger.BessLog.Infoln("downlink data notification listener stopped")
+			return
+		default:
+		}
+
+		var d net.Dialer
+
+		conn, err := d.DialContext(context.Background(), "unixpacket", notifySockAddr)
 		if err != nil {
+			logger.BessLog.Errorf("dial %v failed, retrying in %v: %v", notifySockAddr, notifyRedialInterval, err)
+			b.waitBeforeRedial()
+
+			continue
+		}
+
+		// Exit may have run while this dial was in flight, and it can only close a
+		// connection it can see. Without this the listener parks on a read nobody
+		// will interrupt, holding the socket open past shutdown.
+		if b.stopping() {
+			conn.Close()
+			logger.BessLog.Infoln("downlink data notification listener stopped")
+
 			return
 		}
 
-		d := buf[0:8]
-		fseid := binary.LittleEndian.Uint64(d)
+		logger.BessLog.Infoln("connected to downlink data notification socket:", notifySockAddr)
+
+		b.setNotifyConn(conn)
+		b.readNotifications(conn, notifier)
+		b.closeNotifyConn()
+
+		b.waitBeforeRedial()
+	}
+}
+
+// readNotifications consumes notifications until the connection fails, and
+// reports why it stopped -- silence here is indistinguishable from an idle
+// network, which is what made this failure invisible.
+func (b *bess) readNotifications(conn net.Conn, notifier *downlinkDataNotifier) {
+	for {
+		buf := make([]byte, 512)
+
+		n, err := conn.Read(buf)
+		if err != nil {
+			if b.stopping() {
+				return
+			}
+
+			logger.BessLog.Errorln("downlink data notification socket read failed, reconnecting:", err)
+
+			return
+		}
+
+		if n < 8 {
+			logger.BessLog.Warnln("short downlink data notification, want at least 8 bytes, got:", n)
+			continue
+		}
+
+		fseid := binary.LittleEndian.Uint64(buf[0:8])
 
 		notifier.Notify(fseid)
+	}
+}
+
+func (b *bess) setNotifyConn(conn net.Conn) {
+	b.notifyMu.Lock()
+	defer b.notifyMu.Unlock()
+
+	b.notifyConn = conn
+}
+
+// closeNotifyConn closes the live notification connection if there is one. It is
+// safe to call from the listener and from Exit concurrently, and twice.
+func (b *bess) closeNotifyConn() {
+	b.notifyMu.Lock()
+	defer b.notifyMu.Unlock()
+
+	if b.notifyConn == nil {
+		return
+	}
+
+	b.notifyConn.Close()
+	b.notifyConn = nil
+}
+
+func (b *bess) stopping() bool {
+	select {
+	case <-b.notifyStop:
+		return true
+	default:
+		return false
+	}
+}
+
+func (b *bess) waitBeforeRedial() {
+	select {
+	case <-b.notifyStop:
+	case <-time.After(notifyRedialInterval):
 	}
 }
 
@@ -810,14 +927,13 @@ func (b *bess) SetUpfInfo(u *upf, conf *Conf) {
 			notifySockAddr = SockAddr
 		}
 
-		var d net.Dialer
-		b.notifyBessSocket, err = d.DialContext(context.Background(), "unixpacket", notifySockAddr)
-		if err != nil {
-			logger.BessLog.Errorln("dial error:", err)
-			return
-		}
+		// The listener dials for itself and keeps redialing. Dialing here instead
+		// meant a datapath that was not yet accepting connections cost this
+		// process its notification path permanently, and took the end-marker
+		// setup below down with it by returning early.
+		b.notifyStop = make(chan struct{})
 
-		go b.notifyListen(u.reportNotifyChan)
+		go b.notifyListen(u.reportNotifyChan, notifySockAddr)
 	}
 
 	if conf.EnableEndMarker {

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -726,9 +726,11 @@ func (b *bess) notifyListen(reportNotifyChan chan<- uint64, notifySockAddr strin
 		}
 
 		// Exit may have run while this dial was in flight, and it can only close a
-		// connection it can see. Without this the listener parks on a read nobody
-		// will interrupt, holding the socket open past shutdown.
-		if b.stopping() {
+		// connection it can see. Registering and checking for shutdown have to happen
+		// together, or the two orders differ: with the check first, Exit can look at an
+		// empty slot and close nothing, and this goroutine then registers a connection
+		// nobody will ever close and parks on a read nobody will interrupt.
+		if !b.adoptNotifyConn(conn) {
 			conn.Close()
 			logger.BessLog.Infoln("downlink data notification listener stopped")
 
@@ -736,8 +738,6 @@ func (b *bess) notifyListen(reportNotifyChan chan<- uint64, notifySockAddr strin
 		}
 
 		logger.BessLog.Infoln("connected to downlink data notification socket:", notifySockAddr)
-
-		b.setNotifyConn(conn)
 		b.readNotifications(conn, notifier)
 		b.closeNotifyConn()
 
@@ -774,11 +774,25 @@ func (b *bess) readNotifications(conn net.Conn, notifier *downlinkDataNotifier) 
 	}
 }
 
-func (b *bess) setNotifyConn(conn net.Conn) {
+// adoptNotifyConn registers conn as the live notification connection and reports whether
+// it was adopted. It refuses once shutdown has begun.
+//
+// The stop check belongs inside notifyMu, which closeNotifyConn also takes, because Exit
+// closes notifyStop before taking that lock. That ordering leaves exactly two possible
+// interleavings and both are safe: adopt runs first and Exit finds the connection to
+// close, or Exit runs first and adopt sees the closed channel and refuses. Checking the
+// channel outside the lock admits a third, where neither closes the connection.
+func (b *bess) adoptNotifyConn(conn net.Conn) bool {
 	b.notifyMu.Lock()
 	defer b.notifyMu.Unlock()
 
+	if b.stopping() {
+		return false
+	}
+
 	b.notifyConn = conn
+
+	return true
 }
 
 // closeNotifyConn closes the live notification connection if there is one. It is

--- a/pfcpiface/messages_session.go
+++ b/pfcpiface/messages_session.go
@@ -559,9 +559,6 @@ func (pConn *PFCPConn) handleDigestReport(fseid uint64) {
 	srreq.DownlinkDataReport = ie.NewDownlinkDataReport(
 		ie.NewPDRID(uint16(pdrID)))
 
-	// Info, not Debug: this is the only evidence that a downlink notification
-	// became a Session Report. At debug level a silent break in this path looks
-	// exactly like a network with no downlink traffic.
 	logger.PfcpLog.With("F-SEID", fseid, "PDR ID", pdrID).Infoln("sending Downlink Data Report")
 
 	pConn.SendPFCPMsg(srreq)

--- a/pfcpiface/messages_session.go
+++ b/pfcpiface/messages_session.go
@@ -559,7 +559,10 @@ func (pConn *PFCPConn) handleDigestReport(fseid uint64) {
 	srreq.DownlinkDataReport = ie.NewDownlinkDataReport(
 		ie.NewPDRID(uint16(pdrID)))
 
-	logger.PfcpLog.With("F-SEID", fseid, "PDR ID", pdrID).Debugln("sending Downlink Data Report")
+	// Info, not Debug: this is the only evidence that a downlink notification
+	// became a Session Report. At debug level a silent break in this path looks
+	// exactly like a network with no downlink traffic.
+	logger.PfcpLog.With("F-SEID", fseid, "PDR ID", pdrID).Infoln("sending Downlink Data Report")
 
 	pConn.SendPFCPMsg(srreq)
 }

--- a/pfcpiface/notify_reconnect_linux_test.go
+++ b/pfcpiface/notify_reconnect_linux_test.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package pfcpiface
+
+import (
+	"context"
+	"encoding/binary"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestNotifyListenReconnectsAfterSocketLoss covers the failure that made downlink
+// data notifications stop for the life of a pod: the listener returned on the first
+// read error, so the datapath went on writing notifications into a socket with no
+// reader while reporting successful transmits. The second round of this test is the
+// one that fails without the reconnect.
+//
+// unixpacket is Linux-only, hence the build tag.
+func TestNotifyListenReconnectsAfterSocketLoss(t *testing.T) {
+	// Kept in /tmp rather than t.TempDir(): a unix socket path has a hard length
+	// limit that the default temp directory can exceed.
+	dir, err := os.MkdirTemp("/tmp", "ddn-notify")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+
+	defer os.RemoveAll(dir)
+
+	sockAddr := filepath.Join(dir, "notifycp")
+
+	var lc net.ListenConfig
+
+	ln, err := lc.Listen(context.Background(), "unixpacket", sockAddr)
+	if err != nil {
+		t.Fatalf("listen %v: %v", sockAddr, err)
+	}
+
+	defer ln.Close()
+
+	notifications := make(chan uint64, 8)
+
+	b := &bess{notifyStop: make(chan struct{})}
+	defer close(b.notifyStop)
+
+	go b.notifyListen(notifications, sockAddr)
+
+	// sendThenDrop accepts the listener's connection, delivers one notification,
+	// and closes the connection underneath it.
+	sendThenDrop := func(fseid uint64) {
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+
+		buf := make([]byte, 8)
+		binary.LittleEndian.PutUint64(buf, fseid)
+
+		if _, err := conn.Write(buf); err != nil {
+			t.Errorf("write: %v", err)
+		}
+
+		conn.Close()
+	}
+
+	expect := func(want uint64, within time.Duration, what string) {
+		t.Helper()
+
+		select {
+		case got := <-notifications:
+			if got != want {
+				t.Fatalf("%s: got F-SEID %#x, want %#x", what, got, want)
+			}
+		case <-time.After(within):
+			t.Fatalf("%s: no notification within %v", what, within)
+		}
+	}
+
+	// Two distinct F-SEIDs, so the notifier's rate limiter cannot be what carries
+	// or suppresses the second notification.
+	go sendThenDrop(0x1111)
+	expect(0x1111, 5*time.Second, "first connection")
+
+	go sendThenDrop(0x2222)
+	expect(0x2222, 4*notifyRedialInterval+5*time.Second, "after socket loss")
+}

--- a/pfcpiface/notify_shutdown_test.go
+++ b/pfcpiface/notify_shutdown_test.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package pfcpiface
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// trackedConn reports whether it was closed, which is the only thing that matters here: a
+// connection nobody closes is one the listener stays parked on after shutdown.
+type trackedConn struct {
+	net.Conn
+
+	mu     sync.Mutex
+	closed bool
+}
+
+func (c *trackedConn) Close() error {
+	c.mu.Lock()
+	c.closed = true
+	c.mu.Unlock()
+
+	return c.Conn.Close()
+}
+
+func (c *trackedConn) isClosed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.closed
+}
+
+func newTrackedConn(t *testing.T) *trackedConn {
+	t.Helper()
+
+	client, server := net.Pipe()
+	t.Cleanup(func() {
+		client.Close()
+		server.Close()
+	})
+
+	return &trackedConn{Conn: client}
+}
+
+// A connection dialled before shutdown is adopted, and Exit is then able to find and close it.
+func TestNotifyConnAdoptedBeforeShutdownIsClosedByExit(t *testing.T) {
+	b := &bess{notifyStop: make(chan struct{})}
+	conn := newTrackedConn(t)
+
+	if !b.adoptNotifyConn(conn) {
+		t.Fatal("a connection dialled before shutdown must be adopted")
+	}
+
+	close(b.notifyStop)
+	b.closeNotifyConn()
+
+	if !conn.isClosed() {
+		t.Error("the adopted connection was not closed on shutdown; the listener would park on it")
+	}
+}
+
+// A connection that arrives after shutdown has begun is refused, so the caller closes it rather
+// than registering it into a slot that has already been swept.
+func TestNotifyConnIsRefusedAfterShutdownHasBegun(t *testing.T) {
+	b := &bess{notifyStop: make(chan struct{})}
+
+	// The order Exit uses: close the channel, then sweep the slot.
+	close(b.notifyStop)
+	b.closeNotifyConn()
+
+	conn := newTrackedConn(t)
+	if b.adoptNotifyConn(conn) {
+		t.Fatal("a connection dialled after shutdown must be refused; nothing will close it")
+	}
+	if b.notifyConn != nil {
+		t.Error("a refused connection must not be registered")
+	}
+}
+
+// The interleaving the check-then-register version got wrong, driven deterministically rather
+// than hoped for: shutdown happens while the listener is already past its stop check and waiting
+// to register.
+//
+// Holding notifyMu is what makes it reproducible. The listener goroutine parks on the lock; the
+// stop channel is then closed and the slot swept while it waits, which is exactly Exit's order;
+// and only then is the lock released. A stop check taken before the lock has already read false by
+// that point, so the connection would be registered into a slot nothing will sweep again. Taking
+// the check inside the lock is what makes the second read the one that counts.
+func TestNotifyConnIsRefusedWhenShutdownHappensWhileWaitingToRegister(t *testing.T) {
+	b := &bess{notifyStop: make(chan struct{})}
+	conn := newTrackedConn(t)
+
+	b.notifyMu.Lock()
+
+	adopted := make(chan bool, 1)
+
+	go func() {
+		if !b.adoptNotifyConn(conn) {
+			conn.Close() // what the listener does with a refused connection
+		} else {
+			adopted <- true
+		}
+
+		close(adopted)
+	}()
+
+	// Let the goroutine reach adoptNotifyConn and park on the lock. Any stop check outside the
+	// lock has been evaluated by now, and it read false.
+	time.Sleep(50 * time.Millisecond)
+
+	// Exit's order, with the lock held so the listener cannot interleave: signal, then sweep.
+	close(b.notifyStop)
+	b.notifyConn = nil
+
+	b.notifyMu.Unlock()
+
+	if <-adopted {
+		t.Fatal("the connection was adopted after shutdown had begun and the slot had been swept; " +
+			"nothing will close it and the listener parks on it for good")
+	}
+
+	if b.notifyConn != nil {
+		t.Error("a refused connection must not be registered")
+	}
+
+	if !conn.isClosed() {
+		t.Error("a refused connection must be closed by its caller")
+	}
+}


### PR DESCRIPTION
### What this fixes

Downlink data notifications from the datapath are what turn a buffered packet into a Session
Report, and a Session Report is the only reason the SMF ever asks the AMF to page a UE. So
losing that path makes every idle UE unreachable for mobile-terminated traffic — and it could
be lost **silently and permanently**.

`notifyListen` returned on the first read error: no log line, no reconnect, no liveness check.
The datapath went on writing notifications into a socket with no reader, and went on reporting
successful transmits, so the only symptom was downlink traffic that never arrived.

Observed on a live deployment, and this is what it looks like from the outside:

```
bessctl show port notifyCP   ->  Out/TX  packets: 46   dropped: 0
N4 capture, same window      ->  0 Session Report Requests
```

The datapath is certain it delivered 46 notifications. Nothing consumed any of them, and no
log line anywhere said so.

There is a second way to lose it: the dial happened inline in `SetUpfInfo`, so a datapath not
yet accepting connections cost the process its notification path for good — and took the
end-marker setup with it, because the failure path returned early.

### What changes

- **The listener owns its connection.** It dials, reads, and on any failure logs the reason and
  reconnects, stopping only when the element shuts down. The rate limiter is created once and
  lives across reconnects, so reconnecting cannot re-notify a session that was reported moments
  earlier.
- **Shutdown closes the socket as well as the stop channel**, since closing a channel cannot end
  a read that is already blocked; and shutdown is re-checked after the dial returns, because
  `Exit` can only close a connection it can see.
- **`sending Downlink Data Report` moves from Debug to Info.** Its failure branches already log
  at Warn and Error, so at the default level a silent break in this path looked exactly like a
  network with no downlink traffic — which is why finding it needed a packet capture rather than
  a log. A notification is rate limited to one per session per 20 s, so the added volume is
  bounded.
- **A short read is logged and skipped** rather than decoded as an F-SEID out of whatever the
  buffer happened to hold.

### Testing

`linux/amd64`, in the images CI pins:

- `go test -race ./pfcpiface/...` green in `golang:1.25.0`
- `golangci-lint run` — **0 issues** in `golangci/golangci-lint:v2.11.3`

The new test delivers a notification, drops the connection underneath the listener, and requires
the next one to arrive. Mutation-checked rather than assumed: with the reconnect reverted it fails
with `after socket loss: no notification within 13s`, and passes with it. `unixpacket` is
Linux-only, hence the build tag.

### Note for reviewers

- **Independent of #1219.** That PR touches `SendMsgToUPF`/`GRPCJoin`; this one touches
  `notifyListen`, the `bess` struct and `Exit`. No shared functions, so either can land first;
  whichever goes second may want a trivial rebase for the other's context in the same file.
- **The Debug→Info change is deliberate and is half the fix.** This defect produced no log line
  at the default level, so the log was actively misleading: it looked like an idle network. If
  you would rather keep it at Debug, the reconnect half still stands on its own — but then the
  next occurrence is again only visible with a capture.
- Reconnect interval is a fixed 2 s with no backoff. The socket is a local unix socket served by
  the datapath in the same pod, so a failure means the datapath is down and the element is not
  useful anyway; I kept it simple rather than adding backoff for a case that does not arise
  independently. Happy to add it if you prefer.
