### PR TITLE
pfcpiface: offer a downlink notification to every association

### DIFF
--- a/pfcpiface/messages_session.go
+++ b/pfcpiface/messages_session.go
@@ -510,11 +510,14 @@ func (pConn *PFCPConn) handleSessionDeletionRequest(msg message.Message) (messag
 	return smres, nil
 }
 
-func (pConn *PFCPConn) handleDigestReport(fseid uint64) {
+// handleDigestReport reports a downlink data notification to the control plane, and
+// returns whether this association is the one holding the session. A notification
+// carries only an F-SEID, so the caller cannot know which association owns it and has
+// to offer it around.
+func (pConn *PFCPConn) handleDigestReport(fseid uint64) bool {
 	session, ok := pConn.store.GetSession(fseid)
 	if !ok {
-		logger.PfcpLog.Warnln("no session found for fseid:", fseid)
-		return
+		return false
 	}
 
 	seq := pConn.getSeqNum()
@@ -544,8 +547,12 @@ func (pConn *PFCPConn) handleDigestReport(fseid uint64) {
 	for _, far := range session.fars {
 		if far.farID == farID {
 			if far.applyAction&ActionNotify == 0 {
+				// This association holds the session, so the notification is answered
+				// here whatever the outcome: offering it on would only find peers that
+				// do not know the F-SEID at all.
 				logger.PfcpLog.Errorln("packet received for forwarding far. discard")
-				return
+
+				return true
 			}
 		}
 	}
@@ -553,7 +560,7 @@ func (pConn *PFCPConn) handleDigestReport(fseid uint64) {
 	if pdrID == 0 {
 		logger.PfcpLog.Errorln("no Pdr found for downlink")
 
-		return
+		return true
 	}
 
 	srreq.DownlinkDataReport = ie.NewDownlinkDataReport(
@@ -562,6 +569,35 @@ func (pConn *PFCPConn) handleDigestReport(fseid uint64) {
 	logger.PfcpLog.With("F-SEID", fseid, "PDR ID", pdrID).Infoln("sending Downlink Data Report")
 
 	pConn.SendPFCPMsg(srreq)
+
+	return true
+}
+
+// pfcpSRRspFlagDROBU is the DROBU bit of the PFCPSRRsp-Flags IE, TS 29.244 8.2.62. It asks
+// the user plane to discard the packets it buffered for the session. go-pfcp offers a
+// HasDROBU helper for PFCPSMReq-Flags but not for these, so the bit is tested here.
+const pfcpSRRspFlagDROBU = 0x01
+
+// reportDropBufferedRequest says when the control plane has asked for buffered packets to
+// be discarded and this element cannot honour it. The BUFF apply action reaches this
+// datapath as notify-only, so there is no store to discard -- honouring DROBU is part of
+// downlink buffering, which is not implemented here. Without this the control plane's log
+// reads as though buffering had been stopped while nothing acted on the request.
+func reportDropBufferedRequest(srres *message.SessionReportResponse) {
+	if srres.PFCPSRRspFlags == nil {
+		return
+	}
+
+	flags, err := srres.PFCPSRRspFlags.PFCPSRRspFlags()
+	if err != nil {
+		logger.PfcpLog.Warnln("could not read PFCPSRRsp-Flags:", err)
+		return
+	}
+
+	if flags&pfcpSRRspFlagDROBU != 0 {
+		logger.PfcpLog.Warnln("DROBU requested for seq, but this datapath notifies rather than buffers, "+
+			"so there is nothing to discard:", srres.SequenceNumber)
+	}
 }
 
 func (pConn *PFCPConn) handleSessionReportResponse(msg message.Message) error {
@@ -583,6 +619,8 @@ func (pConn *PFCPConn) handleSessionReportResponse(msg message.Message) error {
 	if err != nil {
 		return errUnmarshal(err)
 	}
+
+	reportDropBufferedRequest(srres)
 
 	if cause == ie.CauseRequestAccepted {
 		return nil

--- a/pfcpiface/messages_session.go
+++ b/pfcpiface/messages_session.go
@@ -573,7 +573,7 @@ func (pConn *PFCPConn) handleDigestReport(fseid uint64) bool {
 	return true
 }
 
-// pfcpSRRspFlagDROBU is the DROBU bit of the PFCPSRRsp-Flags IE, TS 29.244 8.2.62. It asks
+// pfcpSRRspFlagDROBU is the DROBU bit of the PFCPSRRsp-Flags IE, TS 29.244 8.2.32. It asks
 // the user plane to discard the packets it buffered for the session. go-pfcp offers a
 // HasDROBU helper for PFCPSMReq-Flags but not for these, so the bit is tested here.
 const pfcpSRRspFlagDROBU = 0x01

--- a/pfcpiface/node.go
+++ b/pfcpiface/node.go
@@ -118,12 +118,25 @@ func (node *PFCPNode) Serve() {
 	for !shutdown {
 		select {
 		case fseid := <-node.upf.reportNotifyChan:
-			// TODO: Logic to distinguish PFCPConn based on SEID
+			// Offer the notification to every association until one recognises the
+			// F-SEID. This used to stop at the first, whichever the map happened to
+			// yield: if that association did not hold the session the notification was
+			// dropped with a warning and no Session Report was sent, so an idle UE
+			// stayed unreachable. More than one association is ordinary -- an SMF
+			// talking to this element directly while an adapter is also associated is
+			// enough -- and which one answered was a coin toss.
+			reported := false
+
 			node.pConns.Range(func(key, value interface{}) bool {
 				pConn := value.(*PFCPConn)
-				pConn.handleDigestReport(fseid)
-				return false
+				reported = pConn.handleDigestReport(fseid)
+
+				return !reported
 			})
+
+			if !reported {
+				logger.PfcpLog.Warnln("no association holds a session for fseid, downlink data notification dropped:", fseid)
+			}
 		case <-node.ctx.Done():
 			shutdown = true
 

--- a/pfcpiface/notify_fanout_test.go
+++ b/pfcpiface/notify_fanout_test.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package pfcpiface
+
+import (
+	"net"
+	"testing"
+
+	"github.com/wmnsk/go-pfcp/ie"
+	"github.com/wmnsk/go-pfcp/message"
+)
+
+// notifyConn is an association with its own session store, which is what makes a
+// notification's owner ambiguous when more than one exists.
+func notifyConn(t *testing.T, sessions SessionsStore) *PFCPConn {
+	t.Helper()
+
+	l, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() { l.Close() }) //nolint:errcheck // test cleanup
+
+	return &PFCPConn{Conn: l, store: sessions, upf: &upf{datapath: &fakeDP{}}}
+}
+
+// A downlink data notification carries only an F-SEID, so the node has to offer it to
+// each association until one recognises it. Reporting ownership is what makes that
+// possible: the loop used to stop at the first association the map yielded, and if that
+// one did not hold the session the notification was dropped and no Session Report was
+// sent -- an idle UE left unreachable by which peer happened to be enumerated first.
+func TestHandleDigestReportReportsWhetherItOwnsTheSession(t *testing.T) {
+	const held = uint64(0x1234)
+
+	owner := NewInMemoryStore()
+	if err := owner.PutSession(PFCPSession{localSEID: held, remoteSEID: 0x4321}); err != nil {
+		t.Fatalf("store the session: %v", err)
+	}
+
+	stranger := notifyConn(t, NewInMemoryStore())
+	if stranger.handleDigestReport(held) {
+		t.Error("an association that does not hold the session claimed the notification")
+	}
+
+	// The owner has no PDR for the downlink, so no report is built -- but it must still
+	// claim the notification, or the node would go on offering it to peers that do not
+	// know the F-SEID at all.
+	if !notifyConn(t, owner).handleDigestReport(held) {
+		t.Error("the association holding the session did not claim the notification")
+	}
+}
+
+// The control plane's only lever for "stop buffering" is a flag this datapath cannot act
+// on, so the one thing it can do is say so. Guarding mainly that reading the flags of a
+// response that has none does not panic, and that the bit is the one TS 29.244 names.
+func TestReportDropBufferedRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		rsp  *message.SessionReportResponse
+	}{
+		{
+			name: "no flags IE at all",
+			rsp:  message.NewSessionReportResponse(0, 0, 1, 1, 0, ie.NewCause(ie.CauseRequestRejected)),
+		},
+		{
+			name: "flags without DROBU",
+			rsp: message.NewSessionReportResponse(0, 0, 1, 1, 0,
+				ie.NewCause(ie.CauseRequestRejected), ie.NewPFCPSRRspFlags(0x00)),
+		},
+		{
+			name: "DROBU requested",
+			rsp: message.NewSessionReportResponse(0, 0, 1, 1, 0,
+				ie.NewCause(ie.CauseRequestRejected), ie.NewPFCPSRRspFlags(pfcpSRRspFlagDROBU)),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reportDropBufferedRequest(tc.rsp)
+		})
+	}
+}


### PR DESCRIPTION
> **Stacked on #1225.** The diff shown here includes that PR's commit until it merges; the commit
> to review is the second one. They are separable in behaviour but both touch
> `handleDigestReport`, so this is based on it rather than racing it.

### What this fixes

A downlink data notification carries only an F-SEID. `PFCPNode.Serve` offered it to the first
association the map happened to yield and then stopped:

```go
        case fseid := <-node.upf.reportNotifyChan:
                // TODO: Logic to distinguish PFCPConn based on SEID
                node.pConns.Range(func(key, value interface{}) bool {
                        pConn := value.(*PFCPConn)
                        pConn.handleDigestReport(fseid)
                        return false          // <- stops after one, whichever it was
                })
```

If that association did not hold the session, `handleDigestReport` logged
`no session found for fseid` and returned, **no Session Report was sent**, and an idle UE stayed
unreachable. Which association answered was decided by map iteration order. The `TODO` on that
line names the problem.

More than one association is ordinary rather than exotic — an SMF talking to this element directly
while an adapter is also associated is enough, which is exactly what switching an SMF to adapter
mode without restarting this element leaves behind. In that state mobile-terminated reachability
becomes a coin toss, and it plausibly explains paging that works and then does not on the same
build.

### What changes

- `handleDigestReport` reports **whether it holds the session**, and the node offers the
  notification on until one does — or says that none did.
- A session that is found but cannot be reported on (a forwarding FAR, no downlink PDR) still
  claims the notification. Offering it on would only reach peers that do not know the F-SEID at
  all.
- The per-association `no session found` warning is replaced by one at the point where the outcome
  is actually known. Otherwise every association that does not hold a given session logs for every
  notification.

### Second, smaller thing: report DROBU when it cannot be honoured

`handleSessionReportResponse` reads the Cause and, in one branch, the SEID. The PFCPSRRsp-Flags
were never parsed — so DROBU, the control plane's only instruction to stop buffering, did nothing
and said nothing. The control plane's own log then reads as though buffering had been stopped.

It cannot be honoured here, and that is the point of the message: `ActionBuffer` reaches this
datapath as `farNotify`, so there is no store to discard. Honouring it is part of downlink
buffering, which this element does not implement. The check runs before the accepted-cause return,
so a response carrying the flag is reported either way.

### Testing

`linux/amd64`, in the images CI pins:

- `go test -race ./pfcpiface/...` green in `golang:1.25.0`
- `golangci-lint run` — **0 issues** in `golangci/golangci-lint:v2.11.3`

The fan-out test is mutation-checked: making `handleDigestReport` claim ownership unconditionally
fails it with `an association that does not hold the session claimed the notification`.

Verified on a live deployment — a downlink packet to an idle UE produces
`sending Downlink Data Report`, a Session Report to the SMF, Paging on N2, and the UE's user plane
back 18 ms later, with no `no association holds a session` warning while a single association is up.

### Note for reviewers

I did **not** key `pConns` by SEID, which is the shape the `TODO` suggests. Asking each association
in turn is O(associations) with a very small constant on a path that is already rate limited to one
notification per session per 20 s, and it avoids maintaining a second index that has to be kept
consistent with session create and delete on every association. If you would rather have the index,
I am happy to do it that way instead.
