### PR TITLE
fix(pfcpiface): report a QER the datapath refused as a failure

### DIFF
--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -1481,7 +1481,14 @@ func (b *bess) processQER(ctx context.Context, arg *anypb.Any, method upfMsgType
 
 	if err != nil || resp.GetError() != nil {
 		logger.BessLog.Errorf("%v for qer %v failed with resp: %v, error: %v", qosTableName, methods[method], resp, err)
-		return err
+
+		if err != nil {
+			return err
+		}
+
+		// The RPC itself succeeded and the module refused the rule, so err is nil.
+		// Returning it would report the refusal to the caller as success.
+		return ErrOperationFailedWithReason(qosTableName+" "+methods[method], resp.GetError().String())
 	}
 
 	return nil

--- a/pfcpiface/bess_qer_test.go
+++ b/pfcpiface/bess_qer_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Forsway Scandinavia AB
+
+package pfcpiface
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pb "github.com/omec-project/upf-epc/pfcpiface/bess_pb"
+	"google.golang.org/grpc"
+)
+
+// moduleCommandStub answers ModuleCommand with whatever the test needs and leaves the
+// rest of BESSControlClient unimplemented, which is enough for processQER.
+type moduleCommandStub struct {
+	pb.BESSControlClient
+
+	resp *pb.CommandResponse
+	err  error
+}
+
+func (s moduleCommandStub) ModuleCommand(
+	_ context.Context, _ *pb.CommandRequest, _ ...grpc.CallOption,
+) (*pb.CommandResponse, error) {
+	return s.resp, s.err
+}
+
+// A module that refuses a rule answers over a healthy RPC: the gRPC error is nil and
+// the refusal is carried in the response. Reporting that as success tells the caller
+// the datapath holds a rule it has in fact rejected.
+func TestProcessQERReportsAModuleRefusal(t *testing.T) {
+	b := &bess{client: moduleCommandStub{
+		resp: &pb.CommandResponse{Error: &pb.Error{Code: 1, Errmsg: "table is full"}},
+	}}
+
+	err := b.processQER(context.Background(), nil, upfMsgTypeAdd, "appQERLookup")
+	if err == nil {
+		t.Fatal("processQER() = nil for a refused rule, want an error")
+	}
+}
+
+func TestProcessQERReportsAFailedRPC(t *testing.T) {
+	rpcErr := errors.New("connection refused")
+	b := &bess{client: moduleCommandStub{err: rpcErr}}
+
+	err := b.processQER(context.Background(), nil, upfMsgTypeAdd, "appQERLookup")
+	if !errors.Is(err, rpcErr) {
+		t.Errorf("processQER() = %v, want the RPC error", err)
+	}
+}
+
+func TestProcessQERAcceptsAnInstalledRule(t *testing.T) {
+	b := &bess{client: moduleCommandStub{resp: &pb.CommandResponse{}}}
+
+	if err := b.processQER(context.Background(), nil, upfMsgTypeAdd, "appQERLookup"); err != nil {
+		t.Errorf("processQER() = %v, want nil for a rule the module took", err)
+	}
+}
+
+func TestProcessQERRejectsAnUnknownMethod(t *testing.T) {
+	b := &bess{client: moduleCommandStub{resp: &pb.CommandResponse{}}}
+
+	if err := b.processQER(context.Background(), nil, upfMsgTypeMod, "appQERLookup"); err == nil {
+		t.Error("processQER() = nil for an unsupported method, want an error")
+	}
+}


### PR DESCRIPTION
## What

`processQER` reports a rule the datapath refused as a successful install.

```go
resp, err := b.client.ModuleCommand(ctx, &pb.CommandRequest{...})

if err != nil || resp.GetError() != nil {
    logger.BessLog.Errorf("%v for qer %v failed with resp: %v, error: %v", qosTableName, methods[method], resp, err)
    return err
}
```

The condition covers two different failures but the return only carries one. When BESS
refuses the rule, the RPC itself succeeded: `err` is `nil` and the refusal arrives in
`resp.Error`. The function logs it and then returns `nil`. Only a transport failure is
ever reported to the caller.

`processQER` is the only one of the five `process*` helpers that returns an error —
`processPDR`, `processFAR`, `processSliceMeter` and `processGtpuPathMonitoring` are
`void` and merely log — so it is the one place where a refusal can be mistaken for a
successful install.

## The fix

Return the transport error when there is one, and build an error from the response when
the module refused. The log line is unchanged.

## Scope, and what this deliberately does not do

**The only observable change is an extra log line.** All six call sites — the two
`upfMsgTypeClear` calls in `SetUpfInfo` and the add/del pairs in `addApplicationQER`,
`delApplicationQER`, `addSessionQER` and `delSessionQER` — do exactly one thing with the
returned error: log it. None propagate it, none branch on it. I checked all six.

Making the result actually propagate to the PFCP cause is a separate and visible
behaviour change: sessions that are silently accepted today would start being rejected.
That belongs with #1219, and it must not land before it. While `GRPCJoin` short-circuits
on the first failure, truthful error reporting can leave a batch reported as refused
having already programmed part of itself — a datapath-state hazard rather than a
cosmetic one.

This PR is therefore the safe half: it stops the callee lying, without making any
failure path reachable that is not reachable today.

## Related

Not a fix for #873, but relevant to anyone reading it: that issue reports
`appQERLookupFail` counts, and this defect is why a QER the module rejected leaves no
trace beyond a log line.

## Verification

On `linux/amd64` in `golang:1.25.0`:

- `go build ./...`, `go vet ./pfcpiface/...` — clean
- `go test -race -count=1 ./pfcpiface/` — ok
- New tests cover a module refusal, a failed RPC, a successful install and an
  unsupported method. Mutation check: restoring `return err` makes
  `TestProcessQERReportsAModuleRefusal` fail with
  `processQER() = nil for a refused rule, want an error`.
- `golangci-lint` **v2.11.3** (the version pinned in `.github/workflows/main.yml`):
  `0 issues`; `golangci-lint fmt --diff ./...` produces no output
- `reuse lint`: 148/148, compliant

`go test -race ./...` across the whole tree fails in `pfcpiface` with
`listen udp :8805: bind: address already in use`, because the package tests and
`test/integration` both bind PFCP 8805 when the packages run in parallel. **This
reproduces identically on unmodified `upstream/main`**, so it is pre-existing and
environmental, not from this change. Each package passes on its own.
