### PR TITLE
fix(conf): read each table size independently

### DIFF
--- a/conf/parser.py
+++ b/conf/parser.py
@@ -194,17 +194,24 @@ class Parser:
         except KeyError:
             print("Flow measurement function disabled")
 
-        # Table sizes
-        try:
-            self.table_size_pdr_lookup = self.conf["table_sizes"]["pdrLookup"]
-            self.table_size_flow_measure = self.conf["table_sizes"]["flowMeasure"]
-            self.table_size_app_qer_lookup = self.conf["table_sizes"]["appQERLookup"]
-            self.table_size_session_qer_lookup = self.conf["table_sizes"][
-                "sessionQERLookup"
-            ]
-            self.table_size_far_lookup = self.conf["table_sizes"]["farLookup"]
-        except KeyError:
+        # Table sizes. Read each key on its own: sharing one try/except meant a single
+        # absent key raised part-way and silently discarded every size after it, leaving
+        # those tables on the module default while the configured values were ignored.
+        table_sizes = self.conf.get("table_sizes", {})
+        if not table_sizes:
             print("No explicit table sizes")
+
+        for key, attr in (
+            ("pdrLookup", "table_size_pdr_lookup"),
+            ("flowMeasure", "table_size_flow_measure"),
+            ("appQERLookup", "table_size_app_qer_lookup"),
+            ("sessionQERLookup", "table_size_session_qer_lookup"),
+            ("farLookup", "table_size_far_lookup"),
+        ):
+            if key in table_sizes:
+                setattr(self, attr, table_sizes[key])
+            elif table_sizes:
+                print("No explicit table size for {}, using default".format(key))
 
         # GTPu Path Monitoring
         try:


### PR DESCRIPTION
## What

`Parser.parse` reads the five `table_sizes` keys inside a single `try`/`except KeyError`:

```python
try:
    self.table_size_pdr_lookup         = self.conf["table_sizes"]["pdrLookup"]
    self.table_size_flow_measure       = self.conf["table_sizes"]["flowMeasure"]
    self.table_size_app_qer_lookup     = self.conf["table_sizes"]["appQERLookup"]
    self.table_size_session_qer_lookup = self.conf["table_sizes"]["sessionQERLookup"]
    self.table_size_far_lookup         = self.conf["table_sizes"]["farLookup"]
except KeyError:
    print("No explicit table sizes")
```

The first absent key raises, and every assignment after it is skipped. Those attributes
keep their `0` initialiser, and since `Metering::Init` and `ExactMatchTable::Init`
override the table size only `if (entries)`, the affected tables fall back to the
built-in default of `1 << 15` = 32768 while the configured values are silently ignored.

The only signal is one `No explicit table sizes` line — which is also what a config with
no `table_sizes` at all prints, so it does not distinguish "none configured" from "four
configured and three thrown away".

## Why this is not hypothetical

Ordering decides which values survive. With `flowMeasure` missing — which is the case for
the `bess-upf` values in `omec-project/sdcore-helm-charts` (see
omec-project/sdcore-helm-charts#166) — `pdrLookup` is applied because it precedes the
raising line, and `appQERLookup`, `sessionQERLookup` and `farLookup` are all discarded.

`appQERLookup` keys on `(src_iface, qer_id, fseid)` and takes four entries per session, so
a UPF configured for 200000 entries actually ran with 32768 and stopped programming
application QoS past the **8192nd session**. Beyond that, sessions are established over
PFCP and their packets match a PDR, decapsulate, and are dropped at `appQERLookupFail`.

Nothing reports it. `Qos::CommandAdd` discards the return value of `table_.Add()` and
returns `CommandSuccess()`, which is the still-open concern in #351.

Measured on a deployment carrying 10788 sessions, changing only the config key:

| | before | after |
|---|---:|---:|
| `appQERLookup` rules | 32768 | 43152 (= 4 × 10788) |
| UEs passing traffic | 8174 | 10781 |

## The fix

Read each key independently. A missing key now leaves only its own table on the module
default, and the message names which table it applies to. Behaviour is unchanged for a
config that sets all five, and for one that sets no `table_sizes` at all.

Verified against three configs:

| config | before | after |
|---|---|---|
| all five keys | all five applied | unchanged |
| no `flowMeasure` | `pdrLookup` only; three discarded | four applied, `flowMeasure` defaults |
| no `table_sizes` | all default | unchanged |
