### PR TITLE
refactor: modularize traffic class monitoring and simplify loop closures

### DIFF
--- a/bess/bessctl/commands.py
+++ b/bess/bessctl/commands.py
@@ -1907,91 +1907,88 @@ TcCounterRate = collections.namedtuple('TcCounterRate',
                                        ['count', 'cycles', 'bits', 'packets'])
 
 
+def _calculate_tc_delta(old, new):
+    """Calculate rate-based statistics for traffic class."""
+    sec_diff = new.timestamp - old.timestamp
+    return TcCounterRate(
+        count=(new.count - old.count) / sec_diff,
+        cycles=(new.cycles - old.cycles) / sec_diff,
+        bits=(new.bits - old.bits) / sec_diff,
+        packets=(new.packets - old.packets) / sec_diff
+    )
+
+def _format_tc_data(delta):
+    """Calculate ratios and format traffic class data for display."""
+    ppb = delta.packets / delta.count if delta.count >= 1 else 0.0
+    cpp = delta.cycles / delta.packets if delta.packets >= 1 else 0.0
+    return (delta.cycles / 1e6, int(delta.count), delta.packets / 1e6, delta.bits / 1e6, ppb, cpp)
+
+def _monitor_tc_loop(cli, tcs, wids, max_len, fields, csv_f=None):
+    """Main monitoring loop for traffic classes."""
+    last_stats = {tc: cli.bess.get_tc_stats(tc) for tc in tcs}
+
+    while True:
+        time.sleep(1)
+        current_stats = {tc: cli.bess.get_tc_stats(tc) for tc in tcs}
+
+        # 1. Write Header
+        timestamp = current_stats[tcs[-1]].timestamp
+        cli.fout.write('\n')
+        fmt_head = '{:<%d}{:>12}{:>12}{:>12}{:>12}{:>12}{:>12}\n' % (max_len,)
+        cli.fout.write(fmt_head.format(time.strftime('%X') + str(timestamp % 1)[1:8], *fields))
+        cli.fout.write('{}\n'.format('-' * (72 + max_len)))
+
+        # 2. Write Data for each TC
+        for tc in tcs:
+            delta = _calculate_tc_delta(last_stats[tc], current_stats[tc])
+            data = _format_tc_data(delta)
+            tc_display_name = 'W{} {}'.format(wids[tc], tc)
+
+            fmt_data = '{:<%d}{:>12.3f}{:>12d}{:>12.3f}{:>12.3f}{:>12.3f}{:>12.3f}\n' % (max_len,)
+            cli.fout.write(fmt_data.format(tc_display_name, *data))
+
+            if csv_f is not None:
+                csv_line = '{},{},{}\n'.format(
+                    time.strftime('%X'),
+                    tc_display_name,
+                    ','.join('{:.3f}'.format(x) for x in data)
+                )
+                csv_f.write(csv_line)
+
+        # 3. Write Footer and update stats
+        cli.fout.write('{}\n'.format('-' * (72 + max_len)))
+        last_stats = current_stats
+
 def _monitor_tcs(cli, *tcs):
+    """Monitor traffic class statistics."""
     GUTTER_WIDTH = 5
     FIELDS = ('CPU MHz', 'scheduled', 'Mpps', 'Mbps', 'pkts/sched', 'cycles/p')
 
-    def get_delta(old, new):
-        sec_diff = new.timestamp - old.timestamp
-        delta = TcCounterRate(count=(new.count - old.count) / sec_diff,
-                              cycles=(new.cycles - old.cycles) / sec_diff,
-                              bits=(new.bits - old.bits) / sec_diff,
-                              packets=(new.packets - old.packets) / sec_diff)
-        return delta
-
-    def print_header(timestamp, name_len):
-        cli.fout.write('\n')
-        fmt = '{:<%d}{:>12}{:>12}{:>12}{:>12}{:>12}{:>12}\n' % (name_len,)
-        cli.fout.write(fmt.format(time.strftime('%X') + str(timestamp % 1)[1:8], *FIELDS))
-
-        cli.fout.write('{}\n'.format(('-' * (72 + name_len))))
-
-    def print_footer(name_len):
-        cli.fout.write('{}\n'.format('-' * (72 + name_len)))
-
-    def print_delta(timestamp, tc, delta, name_len, csv_f=None):
-        if delta.count >= 1:
-            ppb = delta.packets / delta.count
-        else:
-            ppb = 0.
-
-        if delta.packets >= 1:
-            cpp = delta.cycles / delta.packets
-        else:
-            cpp = 0.
-
-        data = (delta.cycles / 1e6, int(delta.count), delta.packets / 1e6, delta.bits / 1e6, ppb, cpp)
-        fmt = '{:<%d}{:>12.3f}{:>12d}{:>12.3f}{:>12.3f}{:>12.3f}{:>12.3f}\n' % (name_len,)
-        cli.fout.write(fmt.format(tc, *data))
-        if csv_f is not None:
-            csv_f.write('{},{},{}\n'.format(time.strftime('%X'), tc, ','.join(map(lambda x: '{:.3f}'.format(x), data))))
-
-    def print_loop(csv=None):
-        while True:
-            time.sleep(1)
-
-            for tc in tcs:
-                now[tc] = cli.bess.get_tc_stats(tc)
-
-            print_header(now[tc].timestamp, max_len)
-
-            for tc in tcs:
-                print_delta(now[tc].timestamp, 'W{} {}'.format(wids[tc], tc),
-                            get_delta(last[tc], now[tc]), max_len, csv)
-
-            print_footer(max_len)
-
-            for tc in tcs:
-                last[tc] = now[tc]
-
+    # Get TC information
     all_tcs = cli.bess.list_tcs().classes_status
     wids = {}
     max_len = 0
+
     for tc in all_tcs:
         class_ = getattr(tc, 'class')
         max_len = max(len(class_.name), max_len)
         wids[class_.name] = class_.wid
     max_len += GUTTER_WIDTH
 
+    # Determine which TCs to monitor
     if not tcs:
-        tcs = [getattr(tc, 'class').name for tc in all_tcs]
+        tcs =[getattr(tc, 'class').name for tc in all_tcs]
         if not tcs:
             raise cli.CommandError('No traffic class to monitor')
 
     cli.fout.write('Monitoring traffic classes: {}\n'.format(', '.join(tcs)))
 
-    last = {}
-    now = {}
-
-    for tc in tcs:
-        last[tc] = cli.bess.get_tc_stats(tc)
-
     try:
         csv_path = os.getenv('CSV', None)
         with open(csv_path, 'w') if csv_path is not None else noop() as csv_f:
             if csv_f is not None:
-                csv_f.write('{}\n'.format(','.join(('Timestamp','traffic class',) + FIELDS)))
-            print_loop(csv_f)
+                csv_f.write('{}\n'.format(','.join(('Timestamp', 'traffic class') + FIELDS)))
+            _monitor_tc_loop(cli, tcs, wids, max_len, FIELDS, csv_f)
     except KeyboardInterrupt:
         pass
 


### PR DESCRIPTION
**Description**
This PR refactors _monitor_tcs to resolve cognitive complexity and flatten deeply nested closures. The helper functions, print generators, and rate calculations used to report traffic class (TC) runtime metrics have been moved to module-level private functions.

**Key Changes**

- Decoupled Monitoring Loop: Extracted the core loop execution to _monitor_tc_loop to keep the primary CLI command interface clean.
- Isolated Rate Calculations:
    - Moved the delta calculations and metric differential parsing to _calculate_tc_delta.
    - Moved TC scheduling ratio calculations (packets-per-batch and cycles-per-packet ratios) to _format_tc_data.
- Standardized Terminal Layouts: Replaced nested print format generators with simplified, flat templates and modernized CSV output generation using list comprehensions instead of maps with lambdas.
- Fixed Variable Scope Reliance: Correctly accessed the final TC index in the header generator instead of relying on scoped variable leakage from the loops.