### PR TITLE
fix(pfcpiface): reject a rule batch the datapath reported as failed

### DIFF
--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -129,15 +129,23 @@ func (b *bess) AddSliceInfo(sliceInfo *SliceInfo) error {
 
 	b.addSliceMeter(ctx, done, sliceMeterConfig)
 
-	rc := b.GRPCJoin(1, Timeout, done)
+	completed, succeeded := b.GRPCJoin(1, Timeout, done)
 
-	if !rc {
+	if !completed || !succeeded {
 		logger.BessLog.Errorln(errGRPCCallFailed)
 	}
 
 	return nil
 }
 
+// SendMsgToUPF programs a session's rules as one batch and reports the PFCP cause the
+// batch earned: rejected when the batch completed and any rule in it reported a failure,
+// accepted otherwise. The callers use the cause to decide whether the session exists.
+//
+// A batch that did not complete within Timeout is answered as accepted, which is not a
+// claim that its rules were programmed: nothing here knows what a timed-out batch left in
+// the datapath, and answering it as rejected would have the caller forget a session whose
+// rules may still be installed. That case is unchanged from before this cause existed.
 func (b *bess) SendMsgToUPF(
 	method upfMsgType, rules PacketForwardingRules, updated PacketForwardingRules,
 ) uint8 {
@@ -203,9 +211,17 @@ func (b *bess) SendMsgToUPF(
 		}
 	}
 
-	rc := b.GRPCJoin(calls, Timeout, done)
-	if !rc {
+	completed, succeeded := b.GRPCJoin(calls, Timeout, done)
+	if !completed || !succeeded {
 		logger.BessLog.Errorln(errGRPCCallFailed)
+	}
+
+	// Reject only a batch that completed and reported a failure. A batch that timed out
+	// has an unknown subset of its rules programmed and still in flight, so answering it
+	// as rejected would have the caller forget a session the datapath may still be
+	// forwarding for -- which is worse than the accepted answer it gets today.
+	if completed && !succeeded {
+		cause = ie.CauseRequestRejected
 	}
 
 	return cause
@@ -995,8 +1011,8 @@ func (b *bess) setupSliceMeter(conf *Conf) {
 
 		b.addSliceMeter(ctx, done, conf.SliceMeterConfig)
 
-		rc := b.GRPCJoin(1, Timeout, done)
-		if !rc {
+		completed, succeeded := b.GRPCJoin(1, Timeout, done)
+		if !completed || !succeeded {
 			logger.BessLog.Errorln(errGRPCCallFailed)
 		}
 	}
@@ -1728,7 +1744,14 @@ func (b *bess) delSessionQER(ctx context.Context, srcIface uint8, qer qer) {
 }
 
 // GRPCJoin waits for the given number of asynchronous operations, each of which reports
-// exactly one result on done, and reports whether all of them succeeded.
+// exactly one result on done. It reports two separate things: whether the batch
+// completed within the timeout, and whether every operation in it succeeded.
+//
+// They are separate because they tell a caller different things about the datapath. A
+// batch that completed and failed leaves it in a state the caller knows: every operation
+// has finished and reported. A batch that timed out leaves an unknown subset programmed
+// and still in flight, so a caller cannot conclude anything about what the datapath now
+// holds.
 //
 // It waits for every operation to report rather than returning as soon as one fails.
 // The callers use the result to decide what the datapath now holds, and an operation
@@ -1736,7 +1759,7 @@ func (b *bess) delSessionQER(ctx context.Context, srcIface uint8, qer qer) {
 // touches the same rule — leaving the datapath holding a rule the caller believes it
 // has already replaced. A failing batch therefore costs up to the full timeout instead
 // of returning at the first failure, which the timeout already bounds.
-func (b *bess) GRPCJoin(calls int, timeout time.Duration, done chan bool) bool {
+func (b *bess) GRPCJoin(calls int, timeout time.Duration, done chan bool) (bool, bool) {
 	boom := time.After(timeout)
 	succeeded := true
 
@@ -1752,9 +1775,9 @@ func (b *bess) GRPCJoin(calls int, timeout time.Duration, done chan bool) bool {
 			calls--
 		case <-boom:
 			logger.BessLog.Infoln("timed out adding entries")
-			return false
+			return false, false
 		}
 	}
 
-	return succeeded
+	return true, succeeded
 }

--- a/pfcpiface/bess_cause_test.go
+++ b/pfcpiface/bess_cause_test.go
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package pfcpiface
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/omec-project/upf-epc/pfcpiface/bess_pb"
+	"github.com/wmnsk/go-pfcp/ie"
+	"google.golang.org/grpc"
+)
+
+// The cause SendMsgToUPF returns is what every caller in messages_session.go compares
+// against ie.CauseRequestRejected to decide whether the session exists. A batch that
+// did not complete must therefore not be reported as accepted.
+
+// newCauseTestBess builds the datapath the way SetUpfInfo does, so a QER finds the
+// default QCI entry readQciQosMap guarantees.
+func newCauseTestBess() *bess {
+	b := &bess{client: moduleCommandStub{resp: &pb.CommandResponse{}}}
+	b.readQciQosMap(&Conf{})
+
+	return b
+}
+
+// unprogrammableRule is refused by CreatePortRangeCartesianProduct, so addPDR reports
+// its failure without reaching the datapath client at all.
+func unprogrammableRule() pdr {
+	p := pdr{}
+	p.appFilter.srcPortRange = newRangeMatchPortRange(100, 200)
+	p.appFilter.dstPortRange = newRangeMatchPortRange(300, 400)
+
+	return p
+}
+
+func TestSendMsgToUPFRejectsABatchThatDidNotComplete(t *testing.T) {
+	b := newCauseTestBess()
+
+	rules := PacketForwardingRules{pdrs: []pdr{unprogrammableRule()}}
+
+	if cause := b.SendMsgToUPF(upfMsgTypeAdd, rules, PacketForwardingRules{}); cause != ie.CauseRequestRejected {
+		t.Errorf("SendMsgToUPF() = %d for a rule that was never programmed, want CauseRequestRejected (%d)",
+			cause, ie.CauseRequestRejected)
+	}
+}
+
+// A session carries rules of all three kinds, and the ones that programmed fine must not
+// mask the one that did not: a session holding any unprogrammed rule cannot forward what
+// the control plane thinks it can.
+func TestSendMsgToUPFRejectsASessionWithOneUnprogrammedRule(t *testing.T) {
+	b := newCauseTestBess()
+
+	rules := PacketForwardingRules{
+		pdrs: []pdr{{}, unprogrammableRule(), {}},
+		fars: []far{{}},
+		qers: []qer{{}},
+	}
+
+	if cause := b.SendMsgToUPF(upfMsgTypeAdd, rules, PacketForwardingRules{}); cause != ie.CauseRequestRejected {
+		t.Errorf("SendMsgToUPF() = %d for a session with one unprogrammed rule, want CauseRequestRejected (%d)",
+			cause, ie.CauseRequestRejected)
+	}
+}
+
+func TestSendMsgToUPFAcceptsABatchTheDatapathTook(t *testing.T) {
+	b := newCauseTestBess()
+
+	rules := PacketForwardingRules{
+		pdrs: []pdr{{}},
+		fars: []far{{}},
+		qers: []qer{{}},
+	}
+
+	if cause := b.SendMsgToUPF(upfMsgTypeAdd, rules, PacketForwardingRules{}); cause != ie.CauseRequestAccepted {
+		t.Errorf("SendMsgToUPF() = %d for a batch every rule of which was programmed, want CauseRequestAccepted (%d)",
+			cause, ie.CauseRequestAccepted)
+	}
+}
+
+// A message that carries no rules never reaches the join, and answering it as accepted is
+// the behaviour every caller already relies on.
+func TestSendMsgToUPFAcceptsAnEmptyBatch(t *testing.T) {
+	b := &bess{}
+
+	if cause := b.SendMsgToUPF(upfMsgTypeAdd, PacketForwardingRules{}, PacketForwardingRules{}); cause != ie.CauseRequestAccepted {
+		t.Errorf("SendMsgToUPF() = %d for a message carrying no rules, want CauseRequestAccepted (%d)",
+			cause, ie.CauseRequestAccepted)
+	}
+}
+
+// blockingModuleStub holds every datapath call until it is released, so a batch cannot
+// complete within Timeout. The rule goroutines report once released, which the buffered
+// done channel absorbs after the join has already given up.
+type blockingModuleStub struct {
+	pb.BESSControlClient
+
+	release chan struct{}
+}
+
+func (s blockingModuleStub) ModuleCommand(
+	_ context.Context, _ *pb.CommandRequest, _ ...grpc.CallOption,
+) (*pb.CommandResponse, error) {
+	<-s.release
+
+	return &pb.CommandResponse{}, nil
+}
+
+// A batch that did not complete must not be answered as rejected. Nothing here knows what
+// a timed-out batch left in the datapath, and on the establishment path a rejection has
+// the caller remove the session -- so it would forget one whose rules may still be
+// installed and forwarding. Accepted is not a claim that the rules landed; it is the
+// answer that does not destroy state we cannot see.
+func TestSendMsgToUPFDoesNotRejectABatchThatDidNotComplete(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	b := &bess{client: blockingModuleStub{release: release}}
+	b.readQciQosMap(&Conf{})
+
+	rules := PacketForwardingRules{pdrs: []pdr{{}}}
+
+	if cause := b.SendMsgToUPF(upfMsgTypeAdd, rules, PacketForwardingRules{}); cause != ie.CauseRequestAccepted {
+		t.Errorf("SendMsgToUPF() = %d for a batch that timed out, want CauseRequestAccepted (%d); "+
+			"a timed-out batch has an unknown subset of its rules programmed, so rejecting it "+
+			"makes the caller discard a session the datapath may still hold",
+			cause, ie.CauseRequestAccepted)
+	}
+}

--- a/pfcpiface/bess_test.go
+++ b/pfcpiface/bess_test.go
@@ -38,7 +38,12 @@ func TestGRPCJoinWaitsForEveryCallBeforeReturning(t *testing.T) {
 		}()
 	}
 
-	if b.GRPCJoin(calls, time.Second, done) {
+	completed, succeeded := b.GRPCJoin(calls, time.Second, done)
+	if !completed {
+		t.Error("GRPCJoin reported a batch as incomplete when every call reported")
+	}
+
+	if succeeded {
 		t.Error("GRPCJoin reported success for a batch containing a failed call")
 	}
 
@@ -59,8 +64,9 @@ func TestGRPCJoinReportsSuccessWhenEveryCallSucceeds(t *testing.T) {
 		go func() { done <- true }()
 	}
 
-	if !b.GRPCJoin(calls, time.Second, done) {
-		t.Error("GRPCJoin reported failure for a batch in which every call succeeded")
+	if completed, succeeded := b.GRPCJoin(calls, time.Second, done); !completed || !succeeded {
+		t.Errorf("GRPCJoin() = (%t, %t) for a batch in which every call succeeded, want (true, true)",
+			completed, succeeded)
 	}
 }
 
@@ -81,8 +87,9 @@ func TestGRPCJoinReportsFailureWhenAnyCallFails(t *testing.T) {
 		done <- false
 	}()
 
-	if b.GRPCJoin(calls, time.Second, done) {
-		t.Error("GRPCJoin reported success for a batch whose last call failed")
+	if completed, succeeded := b.GRPCJoin(calls, time.Second, done); !completed || succeeded {
+		t.Errorf("GRPCJoin() = (%t, %t) for a batch whose last call failed, want (true, false)",
+			completed, succeeded)
 	}
 }
 
@@ -95,8 +102,9 @@ func TestGRPCJoinReturnsWhenACallNeverReports(t *testing.T) {
 
 	start := time.Now()
 
-	if b.GRPCJoin(2, 50*time.Millisecond, done) {
-		t.Error("GRPCJoin reported success for a batch one of whose calls never reported")
+	if completed, succeeded := b.GRPCJoin(2, 50*time.Millisecond, done); completed || succeeded {
+		t.Errorf("GRPCJoin() = (%t, %t) for a batch one of whose calls never reported, want (false, false)",
+			completed, succeeded)
 	}
 
 	if elapsed := time.Since(start); elapsed > time.Second {


### PR DESCRIPTION
## The defect

`SendMsgToUPF` programs a session's rules as one batch of concurrent gRPC calls, joins them with
`GRPCJoin`, and then discards the answer:

```go
cause := ie.CauseRequestAccepted
...
rc := b.GRPCJoin(calls, Timeout, done)
if !rc {
    logger.BessLog.Errorln(errGRPCCallFailed)
}

return cause
```

`cause` is never assigned again, so a batch in which a rule reported a failure is answered to the
SMF as a successfully established session. The control plane then holds a session the user plane
cannot forward, and nothing anywhere says so.

## `GRPCJoin` now reports completion separately from success

This is the substance of the change, and it is what makes the cause safe to derive.

`GRPCJoin` returned a single bool that conflated two different states: *the batch completed and
something in it failed*, and *the batch timed out*. They tell a caller opposite things about the
datapath. In the first, every operation has finished and reported, so the caller knows what is
programmed. In the second, an unknown subset is programmed and still in flight.

It now returns both, and **only a completed-and-failed batch is answered as rejected.**

## A timed-out batch stays accepted, deliberately

`handleSessionEstablishmentRequest` removes the session on a rejection. Rejecting a timed-out batch
would therefore make the agent forget a session whose rules may still be installed and forwarding
-- which is the failure mode 1219 existed to remove, reintroduced one layer up. Accepted is not a
claim that the rules landed; it is the answer that does not discard state nothing here can see.
`Timeout` is 1 s, which is a realistic budget to exceed under load, so this is not a corner case.

A test pins it: `TestSendMsgToUPFDoesNotRejectABatchThatDidNotComplete`.

## Five of the eight callers already test for the cause they cannot get

| Site | On `CauseRequestRejected` |
| --- | --- |
| `handleSessionEstablishmentRequest` | `RemoveSession`, reply rejected |
| `handleSessionModificationRequest` (add) | `sendError(ErrWriteToDatapath)` |
| `handleSessionModificationRequest` (del) | `sendError(ErrWriteToDatapath)` |
| `handleSessionDeletionRequest` | `sendError(ErrWriteToDatapath)` |
| `handleSessionReportResponse` | reports a failed datapath delete |

All five branches are unreachable on `main`. This PR makes existing code reachable rather than
adding new code. The remaining three call sites -- `conn.go`'s teardown loop and two in
`grpcsim.go` -- discard the return and are unaffected.

## What the rejection path does not do

**It does not roll back, and that is a real consequence rather than a footnote.** On establishment
it removes the session without deleting the rules its other workers *did* program, and without
releasing the UE address that parsing allocated (`parse_pdr.go`'s `LookupOrAllocIP`, released only
on the deletion path). So a rejection orphans datapath entries and leaks one address. The
modification path has the same shape: `session` is a value copy, and on rejection `PutSession` is
skipped, so the store keeps the old rule set while the datapath holds part of the new one.

That is why the trigger is narrowed to a *reported* failure. Those causes -- a rule that cannot be
marshalled, port ranges that cannot be expanded -- indicate a defect or a misconfiguration rather
than transient load, so they are rare, they recur deterministically, and failing loudly is the
right answer. The alternative is a session that silently cannot forward. Rollback on rejection
belongs in its own change; I would rather raise it separately than bundle a second behaviour change
into this one.

## An RPC failure is still answered as accepted

Stating this plainly because the obvious reading of the title is broader than the diff. `addPDR`,
`addFAR` and `addQER` set their result from their own progress rather than from what `processPDR`,
`processFAR` and `processQER` observed. So **neither a bessd that is down nor a rule the datapath
refused over a healthy RPC reaches the join**, and both are still answered as accepted. What this
change covers is a rule the agent itself could not turn into a datapath call, plus the batch
accounting around it. Making the workers report what the datapath said is a separate defect.

I also considered the other two `GRPCJoin` call sites and left both alone: `setupSliceMeter` returns
nothing and its only caller returns nothing, so there is nowhere to propagate to; `AddSliceInfo`
*can* propagate, through `upf.addSliceInfo` to a REST handler, which makes it a second behaviour
change on a different interface and its own PR.

## Verification

All on linux/amd64 in CI's own images at CI's pinned versions:

- `go build ./...`, `go vet ./pfcpiface/` clean.
- CI's exact unit-test command, `go test -race -failfast ./pfcpiface ./cmd/...` -- ok.
- CI's exact integration command, `MODE=native DATAPATH=bess go test -race -failfast -count=1
  ./test/integration/...` -- ok.
- `golangci-lint` at the pinned v2.13.2: `0 issues`; `golangci-lint fmt --diff` empty.
- Five tests in `pfcpiface/bess_cause_test.go`: a completed batch whose rule was never programmed
  is rejected; a session with one unprogrammed rule among rules that programmed fine is still
  rejected; a fully programmed batch is accepted; a message carrying no rules is accepted; and a
  batch that did not complete is **not** rejected. The four existing `GRPCJoin` tests are updated
  for the two-value return and assert completion and success independently.
- **Mutation-verified in both directions.** Removing the cause assignment makes the two negative
  tests fail on a batch that reported a failure. Widening the condition back to `!completed ||
  !succeeded` makes the timeout test fail with the cause it must not return.
