### PR TITLE
fix(bess): report a Qos table insert the datapath refused

### DIFF
--- a/bess/core/modules/qos.cc
+++ b/bess/core/modules/qos.cc
@@ -391,7 +391,12 @@ CommandResponse Qos::CommandAdd(const bess::pb::QosCommandAddArg &arg) {
     }
   }
 
-  table_.Add(v, key);
+  const bess::utils::Error err_add = table_.Add(v, key);
+  if (err_add.first != 0) {
+    return CommandFailure(err_add.first, "Insert Failed - %s",
+                          err_add.second.c_str());
+  }
+
   return CommandSuccess();
 }
 

--- a/bess/core/utils/metering.h
+++ b/bess/core/utils/metering.h
@@ -111,13 +111,18 @@ class Metering {
   Metering() : total_key_size_(0), num_fields_(0) {}
 
   Error Add(const T &val, const MeteringKey &key) {
-    Error err;
     const void *Key_t = (const void *)&key;
     T *val_t = new T(val);
+    // insert_dpdk() forwards rte_hash_add_key_data(), which returns 0 on
+    // success and a negative errno on failure (-ENOSPC for a full table).
+    // Negative rather than non-zero: its no-data path returns a non-negative
+    // index on success.
     int ret = table_->insert_dpdk(Key_t, val_t);
-    if (!ret) {
-      return MakeError(ENOENT, "Dpdk Insert Failed");
+    if (ret < 0) {
+      delete val_t;
+      return MakeError(-ret, "Dpdk Insert Failed");
     }
+
     return MakeError(0);
   }
 

--- a/bess/core/utils/metering_test.cc
+++ b/bess/core/utils/metering_test.cc
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2026 Forsway Scandinavia AB
+ */
+#include "metering.h"
+
+#include <gtest/gtest.h>
+
+#include "../dpdk.h"
+
+using bess::utils::Error;
+using bess::utils::Metering;
+using bess::utils::MeteringKey;
+
+namespace {
+
+// Metering's table is a DPDK rte_hash, so it cannot be created before EAL is
+// up: rte_hash_create() fails, CuckooMap stays in its non-DPDK mode without
+// saying so, and every insert then returns -1 regardless of the table's state.
+// Bringing DPDK up here, rather than relying on some earlier test in the binary
+// to have done it, is what keeps these tests independent of run order.
+class MeteringTest : public ::testing::Test {
+ protected:
+  // InitDpdk() is idempotent and aborts the process if EAL cannot be brought
+  // up, so there is nothing here worth asserting afterwards.
+  void SetUp() override { bess::InitDpdk(); }
+};
+
+MeteringKey KeyOf(uint64_t v) {
+  MeteringKey key = {{0}};
+  key.u64_arr[0] = v;
+
+  return key;
+}
+
+// A rule the table took must be reported as taken. insert_dpdk() forwards
+// rte_hash_add_key_data(), which returns 0 on success, so a condition that
+// treats 0 as the failure case reports every successful insert as an error --
+// and the caller cannot tell that apart from a real refusal.
+TEST_F(MeteringTest, AddReportsSuccessForARuleTheTableTook) {
+  Metering<uint16_t> table;
+  table.Init(sizeof(uint64_t), 1 << 6);
+
+  const Error err = table.Add(0xBEEF, KeyOf(0x1234));
+
+  EXPECT_EQ(0, err.first) << "a rule the table took was reported as a failure: "
+                          << err.second;
+
+  table.DeInit();
+}
+
+// A table with no room left must say so, and say which failure it was. Nothing
+// above this layer knows the capacity, so an add dropped here is invisible to
+// the control plane.
+TEST_F(MeteringTest, AddReportsFailureWhenTheTableIsFull) {
+  const int entries = 1 << 6;
+
+  Metering<uint16_t> table;
+  table.Init(sizeof(uint64_t), entries);
+
+  Error err = std::make_pair(0, std::string());
+  int accepted = 0;
+
+  for (int i = 0; i < entries * 8; i++) {
+    err = table.Add(static_cast<uint16_t>(i), KeyOf(i + 1));
+    if (err.first != 0) {
+      break;
+    }
+    accepted++;
+  }
+
+  // EXPECT rather than ASSERT: an ASSERT returns from the test immediately, so
+  // the table below would never be released. Init() names its rte_hash after
+  // the address of its own member, which is a stack address, so a leaked table
+  // collides by name with the next test's and breaks it -- one failure here
+  // would be reported as several.
+  EXPECT_NE(0, err.first) << "the table accepted " << accepted
+                          << " rules into a " << entries
+                          << "-entry table without reporting a failure";
+  EXPECT_EQ(ENOSPC, err.first)
+      << "a full table must report ENOSPC and not some other errno, so that a "
+         "refusal is distinguishable from a table that was never created; "
+         "reported: "
+      << err.second;
+
+  table.DeInit();
+}
+
+}  // namespace


### PR DESCRIPTION
Closes the datapath half of #351, which asked for exactly this. The `bess.go` half that issue also
asked for -- *"bess.go currently only prints any errors returned from fastpath"* -- was done in
#1230 and #1275.

**#351 shows as closed "Completed", but it was closed by the stale bot rather than by a fix**, so
it is worth saying why I am treating it as live: it carries the `stale/issue` label, its only
comments are the author's cc and two `github-actions` stale warnings, and it was closed on
2022-01-05, five days after the second one. No PR is linked to it and none of its three module
claims had been acted on. "Completed" is simply what GitHub records when that action closes an
issue.

In any case the issue's status is not the evidence here -- the code is. The test added in this PR
fails on `main` at `1cfcb6d` and passes with the change, which is the part that does not depend on
reading a 2021 issue correctly.

## Two defects, and they must be fixed together

**1. `Metering::Add`'s condition is inverted.** `insert_dpdk()` forwards
`rte_hash_add_key_data()`, whose contract is, from `rte_hash.h`:

```
 * @return
 *   - 0 if added successfully
 *   - -EINVAL if the parameters are invalid.
 *   - -ENOSPC if there is no space in the hash for this key.
```

`Metering::Add` tests `if (!ret)`, so it reports `ENOENT "Dpdk Insert Failed"` **exactly when the
insert succeeded**, and reports success when it failed.

**2. `Qos::CommandAdd` discards the result.** `table_.Add(v, key);` is called for its side effect
and the returned `Error` is dropped, so nothing above the module ever learns that a rule was
refused.

Because `Qos::CommandAdd` is `Metering::Add`'s only caller, the inversion is currently
unobservable — the two defects mask each other. **That is why this is one PR and not two:
propagating the error without correcting the sense would make every successful QER install report
a failure.** The inversion alone is invisible; the propagation alone is an outage.

`WildcardMatch::CommandAdd` already does this correctly for the same call (`if (ret < 0)`), and
this change makes `Qos` match it.

For what it is worth, the inversion looks like an easy slip rather than carelessness:
`Metering::Delete` sits immediately below `Add`, has the same three-line shape, and uses
`if (!ret)` **correctly** -- because `CuckooMap::Remove` returns a `bool`, where false means "not
removed". `insert_dpdk` returns an errno, where 0 means success. Two adjacent functions, the same
idiom, opposite conventions. `Delete` is untouched here and is correct as it stands.

## Why it matters, concretely

A `Qos` table that is full accepts no more rules and says nothing. We hit this: an `appQERLookup`
table left on its `1 << 15` default silently capped a UPF at 8 192 sessions with working
application QoS, and **not one install error appeared in ~13 000 lines of agent and BESS logs** —
because of these two defects. The table-size misconfiguration behind our case is separately fixed
(#1231 and sdcore-helm-charts#166), but the silence is the part that made it cost days instead of
minutes, and it is still there for anyone who fills a table for any other reason.

## What changed

- `core/utils/metering.h` — condition corrected to `if (ret < 0)`, matching `WildcardMatch`. The
  errno is propagated as `-ret` rather than a hard-coded `ENOENT`, so a full table now reports
  **ENOSPC**, which is what #351 asked for. One wrinkle worth knowing: `insert_dpdk` returns `-1` when the
  `CuckooMap` is not in DPDK mode -- that is, when `rte_hash_create` failed at `Init` and the table
  does not exist -- which `-ret` maps to `EPERM`. A misleading errno for that condition, but
  strictly better than today's silence; the real fix is to stop discarding the result of table
  creation, noted below. `val_t` is freed on the failure path, which this
  change makes reachable for the first time; it was leaked before. The unused `Error err;` local
  in the same function is dropped.
- `core/modules/qos.cc` — the result is propagated with `CommandFailure`, matching the
  `"Insert Failed - …"` style already used twice in that function.

## Why `CommandAdd` propagates and `CommandDelete` deliberately does not

A reasonable question given this PR, so stating the decision rather than leaving the asymmetry
unexplained: `Qos::CommandDelete` also drops what its table returned, and I have left it alone on
purpose.

`Metering::Delete` reports `ENOENT "rule doesn't exist"` for a key that is not present. On the
delete path that is usually **idempotency, not a refusal** -- tearing down a session re-deletes
rules that may already be gone. Propagating it would be harmless today, because nothing consumes
the result, but it would become actively wrong as soon as anything does: a normal teardown would
report a failed delete, and in `pfcpiface` a rejected deletion keeps the session and does not
release its address. An insert that the datapath refused is a real failure; a delete of something
already absent is not. Happy to revisit if you see it differently.

**Separately, and I am not fixing it here because it is a different defect:**
`Qos::CommandDelete` assigns `ExtractKey`'s `CommandResponse` and never checks it, then calls
`table_.Delete(key)` regardless. `ExtractKey` returns `EINVAL` on a field-count mismatch **before**
it reaches its `memset(key, 0, sizeof(*key))`, so on that path the delete runs against an
uninitialised stack key. `CommandAdd` checks the equivalent call, so the intended shape is already
in the file. I can raise that on its own if useful.

## Not in this PR

- **`ExactMatchTable::AddRule` has the complementary defect** and is left for its own PR: it
  discards `insert_dpdk()`'s return entirely and always returns success, while its caller
  `ExactMatch::CommandAdd` propagates correctly. So `Qos` and `ExactMatch` each have the opposite
  half broken, which is why #351 named both modules.
- `WildcardMatch::CommandAdd` leaks `data_t` on its failure path. That path is already reachable
  today, so it is a live leak, but it is unrelated to the reporting defect.

## Tests, and a note on why they initialise DPDK themselves

`core/utils/metering_test.cc` asserts both directions: a rule the table took is reported as taken,
and a table filled past its configured capacity reports a failure whose errno is specifically
`ENOSPC`.

The fixture calls `bess::InitDpdk()`. That is not boilerplate — it is load-bearing, and worth
flagging because it affects more than this file. `Metering`'s table is a DPDK `rte_hash`, and
before EAL is up `rte_hash_create()` fails, `CuckooMap` stays in its non-DPDK mode without
reporting that, and **every** `insert_dpdk()` then returns `-1` regardless of the table's state.
Written without the fixture, both tests passed in the full `all_test` run and failed when run
alone — they were relying on an earlier test in the binary to have brought EAL up as a side effect
of constructing a `PacketPool`. Asserting `ENOSPC` rather than merely "non-zero" is what makes a
table that was never created distinguishable from a table that is genuinely full.

**The same weakness already exists in `EmTableTest.AddRule`, and it is not introduced here.** That
test currently emits

```
RING: Cannot reserve memory for tailq
HASH: memory allocation failed
```

and still reports `OK`, because `ExactMatchTable::AddRule` discards the `-1` that follows. So it is
asserting success against a table that was never created. I have deliberately left it alone: it
belongs with the `ExactMatchTable::AddRule` fix, where it will start failing and should be fixed by
initialising DPDK in the test rather than by relaxing the assertion.

## Behaviour change

A `Qos.add()` that the datapath refuses now returns an error over gRPC instead of reporting
success. Every caller in `pfcpiface` logs rather than acts, so in practice this puts a log line
where there was silence.

**It does not reach the PFCP cause, and that stays true after #1275.** `addQER` reports
`done <- true` unconditionally and `addApplicationQER`/`addSessionQER` drop what `processQER`
returns, so a module refusal never reaches the join and the session is still answered as accepted.
Closing that is the separate defect described under "What this does not cover". An earlier revision
of this description claimed the opposite; that was wrong.

No previously-succeeding install changes behaviour, and the tests below assert that direction
explicitly.

## How this was verified

Built and run on linux/amd64 against CI's own dependency list from `bess/env/build-dep.yml`
(`./build.py bess`, system DPDK 25.11.0):

- **`MeteringTest` in isolation: 2/2 pass.** Run alone as well as in the suite, because of the EAL
  ordering described above -- the isolated run is the one that actually exercises the fixture.
- **Full `all_test`: 189 of 190 pass.** The single failure is `DmaMemoryPoolTest.PoolSetup`, and it
  is **not from this change**: it reproduces identically on an unmodified `upstream/main` build,
  `memory_test.cc` includes only `memory.h` and two utils headers so it cannot see this diff, it
  still fails with `--ulimit memlock=-1` so it is not the lock limit, and it wants a 1 GB hugepage
  my build host does not provide. `bess-source-tests` is green in CI on #1272, #1271 and #1268, so
  it passes on the runners.
- **Mutation-verified.** Restoring `if (!ret)` and the hard-coded `ENOENT` makes
  `AddReportsSuccessForARuleTheTableTook` fail on a rule the table accepted.
- **`clang-format-14`** (the version this repo's workflow pins) reports all three files clean.
- **What the unit tests do not cover, stated plainly:** they exercise `Metering::Add`, so they pin
  the inverted condition but not `Qos::CommandAdd`'s propagation, which is a module-level path.

  Worth flagging while I am here, because it surprised me: **nothing in CI exercises `Qos` at all.**
  `run_module_tests.py` globs `*.py` (`--test_name` defaults to `*`), so the six `.bess` files in
  `module_tests/` -- including `metering.bess`, `exactmatch-val.bess` and `wildcardmatch-val.bess`
  -- are never run by it, and no `.py` module test touches `Qos` or `Metering`. That is not a
  regression; the glob has been `*.py` since the source was integrated. It does mean the module
  layer here has no automated coverage either way.

  If you would like the refusal path asserted before merge, say so and I will add a **`.py`**
  module test using the existing `BessModuleTestCase` framework, which `run_module_tests.py` would
  actually pick up. I did not want to widen the diff uninvited.


