### PR TITLE
fix(bess): report an ExactMatch table insert the datapath refused

### DIFF
--- a/bess/core/utils/exact_match_table.h
+++ b/bess/core/utils/exact_match_table.h
@@ -190,7 +190,16 @@ class ExactMatchTable {
     }
     const void *Key_t = (const void *)&key;
     T *val_t = new T(val);
-    table_->insert_dpdk(Key_t, val_t);
+    // insert_dpdk() forwards rte_hash_add_key_data(), which returns 0 on
+    // success and a negative errno on failure (-ENOSPC for a full table).
+    // Negative rather than non-zero: its no-data path returns a non-negative
+    // index on success.
+    int ret = table_->insert_dpdk(Key_t, val_t);
+    if (ret < 0) {
+      delete val_t;
+      return MakeError(-ret, "dpdk insert failed");
+    }
+
     return MakeError(0);
   }
 

--- a/bess/core/utils/exact_match_table_test.cc
+++ b/bess/core/utils/exact_match_table_test.cc
@@ -35,6 +35,7 @@
 
 #include <gtest/gtest.h>
 
+#include "../dpdk.h"
 #include "../packet_pool.h"
 #include "endian.h"
 
@@ -45,7 +46,21 @@ using bess::utils::ExactMatchRuleFields;
 using bess::utils::ExactMatchTable;
 using google::protobuf::RepeatedPtrField;
 
-TEST(EmTableTest, AddField) {
+// An ExactMatchTable stores its rules in a DPDK rte_hash, so no table can be
+// created before EAL is up: rte_hash_create() fails, CuckooMap stays in its
+// non-DPDK mode without reporting that, and every lookup then misses. Bringing
+// DPDK up here is what makes these tests independent of the order they run in.
+// Without it, four of them passed only because FindMakeKeysPktBatch runs
+// before them and initialises EAL as a side effect of constructing a
+// PacketPool; run on their own they failed.
+class EmTableTest : public ::testing::Test {
+ protected:
+  // InitDpdk() is idempotent and aborts the process if EAL cannot be brought
+  // up, so there is nothing here worth asserting afterwards.
+  void SetUp() override { bess::InitDpdk(); }
+};
+
+TEST_F(EmTableTest, AddField) {
   ExactMatchTable<uint8_t> em;
   Error err = em.AddField(0, 4, 0, 0);
   ASSERT_EQ(0, err.first);
@@ -58,9 +73,9 @@ TEST(EmTableTest, AddField) {
   ASSERT_EQ(EINVAL, err.first);
 }
 
-TEST(EmTableTest, AddRule) {
+TEST_F(EmTableTest, AddRule) {
   ExactMatchTable<uint16_t> em;
-  em.AddField(0, 4, 0, 0);
+  ASSERT_EQ(0, em.AddField(0, 4, 0, 0).first);
   em.Init(1 << 4);
   ExactMatchRuleFields rule = {
       {0x01, 0x02, 0x03, 0x04},
@@ -71,10 +86,53 @@ TEST(EmTableTest, AddRule) {
   em.DeInit();
 }
 
-TEST(EmTableTest, FindMakeKeysPktBatch) {
+// A table with no room left must say so, and say which failure it was. Nothing
+// above this layer knows the table's capacity, so a rule dropped here would
+// otherwise be reported to the caller as installed.
+TEST_F(EmTableTest, AddRuleReportsAFullTable) {
+  const uint32_t entries = 1 << 6;
+
+  ExactMatchTable<uint16_t> em;
+  ASSERT_EQ(0, em.AddField(0, 4, 0, 0).first);
+  em.Init(entries);
+
+  Error err = std::make_pair(0, std::string());
+  uint32_t accepted = 0;
+
+  for (uint32_t i = 1; i <= entries * 8; i++) {
+    const ExactMatchRuleFields rule = {
+        {static_cast<uint8_t>(i), static_cast<uint8_t>(i >> 8),
+         static_cast<uint8_t>(i >> 16), static_cast<uint8_t>(i >> 24)},
+    };
+
+    err = em.AddRule(static_cast<uint16_t>(i), rule);
+    if (err.first != 0) {
+      break;
+    }
+    accepted++;
+  }
+
+  // EXPECT rather than ASSERT: an ASSERT returns from the test immediately, so
+  // the table below would never be released. Init() names its rte_hash after
+  // the address of its own member, which is a stack address, so a leaked table
+  // collides by name with the next test's and breaks it -- one failure here
+  // would be reported as several.
+  EXPECT_NE(0, err.first) << "the table accepted " << accepted
+                          << " rules into a " << entries
+                          << "-entry table without reporting a failure";
+  EXPECT_EQ(ENOSPC, err.first)
+      << "a full table must report ENOSPC and not some other errno, so that a "
+         "refusal stays distinguishable from a table that was never created; "
+         "reported: "
+      << err.second;
+
+  em.ClearRules();
+  em.DeInit();
+}
+
+TEST_F(EmTableTest, FindMakeKeysPktBatch) {
   const size_t n = 2;
   ExactMatchTable<uint16_t> em;
-  em.Init(1 << 6);
   ExactMatchRuleFields rule = {{0x04, 0x03, 0x02, 0x01}};
   ExactMatchKey keys[n];
   bess::PacketBatch batch;
@@ -83,7 +141,12 @@ TEST(EmTableTest, FindMakeKeysPktBatch) {
   pool.AllocBulk(pkts, n, 0);
   char databuf[32] = {0};
 
+  // Init() sizes the table's key from the fields added so far, so it has to
+  // come after AddField(); called before, it built a table with a key length
+  // of zero, which rte_hash_create() refuses. The assertion below then held
+  // for the wrong reason -- a table that does not exist misses every key.
   ASSERT_EQ(0, em.AddField(0, 4, 0, 0).first);
+  em.Init(1 << 6);
   ASSERT_EQ(0, em.AddRule(0xF00, rule).first);
 
   batch.clear();
@@ -105,7 +168,7 @@ TEST(EmTableTest, FindMakeKeysPktBatch) {
   em.DeInit();
 }
 
-TEST(EmTableTest, LookupOneFieldOneRule) {
+TEST_F(EmTableTest, LookupOneFieldOneRule) {
   ExactMatchTable<uint16_t> em;
   em.AddField(0, 4, 0, 0);
   ExactMatchRuleFields rule = {
@@ -123,7 +186,7 @@ TEST(EmTableTest, LookupOneFieldOneRule) {
   em.DeInit();
 }
 
-TEST(EmTableTest, LookupTwoFieldsOneRule) {
+TEST_F(EmTableTest, LookupTwoFieldsOneRule) {
   ExactMatchTable<uint16_t> em;
   ASSERT_EQ(0, em.AddField(0, 4, 0, 0).first);
   ASSERT_EQ(0, em.AddField(6, 2, 0, 1).first);
@@ -139,7 +202,7 @@ TEST(EmTableTest, LookupTwoFieldsOneRule) {
   em.DeInit();
 }
 
-TEST(EmTableTest, LookupTwoFieldsTwoRules) {
+TEST_F(EmTableTest, LookupTwoFieldsTwoRules) {
   ExactMatchTable<uint16_t> em;
   ASSERT_EQ(0, em.AddField(0, 4, 0, 0).first);
   ASSERT_EQ(0, em.AddField(6, 2, 0, 1).first);
@@ -165,7 +228,7 @@ TEST(EmTableTest, LookupTwoFieldsTwoRules) {
 // This test is for a specific bug introduced at one point
 // where the MakeKeys function didn't clear out any random
 // crud that might be on the stack.
-TEST(EmTableTest, IgnoreBytesPastEnd) {
+TEST_F(EmTableTest, IgnoreBytesPastEnd) {
   ExactMatchTable<uint16_t> em;
   ASSERT_EQ(0, em.AddField(6, 1, 0, 0).first);
   ASSERT_EQ(0, em.AddField(7, 8, 0, 1).first);


### PR DESCRIPTION
The other half of the datapath side of #351, and independent of #1276 -- different files, no
overlap, either can merge first.

## The defect

`ExactMatchTable::AddRule` calls `insert_dpdk()` for its side effect and then returns success
whatever happened:

```cpp
  // Returns 0 on success, non-zero errno on failure.
  Error AddRule(const T &val, const ExactMatchRuleFields &fields) {
    ...
    table_->insert_dpdk(Key_t, val_t);
    return MakeError(0);
  }
```

The code contradicts the contract in its own comment, one line above the signature. A rule the
table refused -- because it is full, for instance -- is reported to the caller as installed.

**This is the missing half rather than a new path.** `ExactMatch::CommandAdd` already does the
right thing with the `Error` it is handed, and `CommandAddRules` propagates it out of its loop, so
making the table layer truthful is all that is needed for a refusal to reach the gRPC client.

That is the mirror image of the `Qos` case in #1276, which is why #351 named both modules: there,
the table layer reported (albeit with an inverted condition) and the *module* discarded. Here the
module propagates and the *table* discards. Neither fix helps the other module.

`DeleteRule`, immediately below, is correct as it stands and is untouched -- `CuckooMap::Remove`
returns a `bool`, where false means "not removed". `insert_dpdk` returns an errno, where 0 means
success. Same shape, different convention; that is the trap in this file.

## Why the condition is `< 0` and not `!= 0`

`insert_dpdk()` dispatches on whether a data pointer was given. With data it forwards
`rte_hash_add_key_data()` (0 on success); **without data it forwards `rte_hash_add_key()`, whose
success value is documented as "a non-negative value that can be used by the caller as an offset
into an array of user data"** -- so a positive return is a success there. `WildcardMatch::CommandAdd`
already tests `if (ret < 0)` for the same call. Both current callers of `AddRule` pass data, so
this is defensive rather than load-bearing, but it is noted in a comment so the condition is not
"simplified" into a bug later.

## The tests needed repairing, and that is most of this diff

Making the insert truthful showed that `EmTableTest` was verifying very little about the DPDK path.
Measured on unmodified `main` at `1cfcb6d`, each test run **on its own**:

| Test | Alone, before | Table creation |
| --- | --- | --- |
| `AddField` | pass | creates none |
| `AddRule` | **pass** | **failed** -- `HASH: memory allocation failed` |
| `FindMakeKeysPktBatch` | pass | **failed** -- `key_len must be greater than 0` |
| `LookupOneFieldOneRule` | **FAIL** | failed |
| `LookupTwoFieldsOneRule` | **FAIL** | failed |
| `LookupTwoFieldsTwoRules` | **FAIL** | failed |
| `IgnoreBytesPastEnd` | **FAIL** | failed |

Three separate problems, all pre-existing:

1. **Four tests only pass in the suite, not alone.** `gtest_main.cc` never calls `bess::InitDpdk()`,
   so before EAL is up `rte_hash_create()` fails, `CuckooMap` stays in its non-DPDK mode without
   saying so, and every lookup misses. Those four passed under `all_test` only because
   `FindMakeKeysPktBatch` runs before them and initialises EAL as a side effect of constructing a
   `PacketPool`. Fixed with a fixture that calls `InitDpdk()` -- idempotent, and documented "safe to
   call multiple times".
2. **`AddRule` asserted a successful insert against a table that did not exist.** The discarded
   return is precisely what hid that, so this test could never have failed for the defect this PR
   fixes.
3. **`FindMakeKeysPktBatch` called `Init()` before `AddField()`**, so `total_key_size()` was 0 and
   `rte_hash_create()` refused the table outright. Its closing assertion -- that bogus packets match
   nothing -- then held for the wrong reason, since a table that does not exist misses every key.
   `Init()` now follows `AddField()`, which is what makes that assertion mean something.

Plus one new test, `AddRuleReportsAFullTable`, which fills a table and requires the refusal to be
reported as **ENOSPC** specifically -- so "full" stays distinguishable from "never created". That
distinction is what caught problem 1 while I was writing it.

### One more thing worth knowing about this file

The new test uses `EXPECT_NE` rather than `ASSERT_NE` for its main assertion, and that is
deliberate. An `ASSERT` returns from the test function immediately, so the `ClearRules()` /
`DeInit()` at the end never runs -- and `Init()` names its `rte_hash` after the address of its own
member, which is a stack address that the next test's table is very likely to reuse.
`CuckooMap::DeInit()` is what calls `rte_hash_free()`, so a skipped teardown leaves that name
registered and `rte_hash_create()` then fails for the next test.

I found this by accident: mutating the fix away made **five** tests fail rather than one, because
the intended failure skipped its own cleanup and broke four later tests by name collision. With
`EXPECT`, the mutation fails exactly the one test that is meant to catch it.

Every test in this file ends with cleanup after assertions that can abort, so the same cascade is
possible from any failure here. I have not restructured them -- they pass, and it would bury this
PR's actual change -- but a `TearDown` that releases the table would make failures in this file
much easier to read.

I have also deliberately not touched the unchecked `em.AddRule(...)` in `LookupOneFieldOneRule`, or
the `.name = "test1"` default in `dpdk_params`; neither is this PR's business.

## Verification

On linux/amd64 with the dependency list from `bess/env/build-dep.yml` (`./build.py bess`, system
DPDK 25.11.0):

- **All 8 `EmTableTest` tests pass run individually**, each with no table-creation error -- the
  before/after of the table above. They also pass as a suite (8/8).
- **Full `all_test`: 188 of 189.** The one failure, `DmaMemoryPoolTest.PoolSetup`, is not from this
  change: it reproduces on an unmodified `main` build, still fails with `--ulimit memlock=-1`, and
  wants a 1 GB hugepage this build host does not have. `bess-source-tests` is green in CI on #1272,
  #1271 and #1268.
- **Mutation-verified:** restoring the discarded `insert_dpdk()` call makes
  `AddRuleReportsAFullTable` -- and only it -- fail, reporting how many rules the table accepted
  without ever signalling one.
- `clang-format-14`, the version this repo's workflow pins for `bess/core`, reports both files clean.

## On #351 being closed

It shows as closed "Completed", but the stale bot closed it: it carries the `stale/issue` label, its
only comments are the author's cc and two `github-actions` stale warnings, and it was closed
2022-01-05, five days after the second. No PR is linked. Its `bess.go` request was addressed by
#1230 and #1275, and two of its three module claims by #1276 and this PR. The third is still open:
351 also asks that `WildcardMatch` report `ENOSPC` rather than `EINVAL` for a full table, and
`wildcard_match.cc` still returns a flat `EINVAL` (and leaks the value it allocated on that path).
None of these four PRs addresses it, so 351 should not be closed on the strength of them. The evidence that matters is not
the issue's status though -- it is that the new test fails on `main` and passes here.

