### PR TITLE
fix(bess): validate the key before deleting a Qos rule

### DIFF
--- a/bess/bessctl/module_tests/qos.py
+++ b/bess/bessctl/module_tests/qos.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2026 Forsway Scandinavia AB
+
+from test_utils import *
+
+
+class BessQosTest(BessModuleTestCase):
+    def test_delete_refuses_a_key_it_could_not_extract(self):
+        # Offset-based fields keep this standalone: the module needs no
+        # metadata provider upstream of it to be built.
+        qos = Qos(
+            fields=[
+                {"offset": 23, "num_bytes": 1},
+                {"offset": 2, "num_bytes": 2},
+            ]
+        )
+
+        # A delete naming the right number of fields is accepted even though no
+        # such rule was ever added. Deleting an absent rule is idempotency on
+        # this path, not a refusal, and this pins that.
+        qos.delete(fields=[{"value_bin": b"\xff"}, {"value_bin": b"\x23\xba"}])
+
+        # A delete naming the wrong number of fields cannot describe a key, so
+        # it must be refused. Left unchecked, ExtractKey() returns EINVAL
+        # before it reaches its memset(), and the module then deletes against
+        # an uninitialised key.
+        with self.assertRaises(bess.Error):
+            qos.delete(fields=[{"value_bin": b"\xff"}])
+
+        self.assertBessAlive()
+
+
+suite = unittest.TestLoader().loadTestsFromTestCase(BessQosTest)
+results = unittest.TextTestRunner(verbosity=2).run(suite)
+
+if results.failures or results.errors:
+    sys.exit(1)

--- a/bess/core/modules/qos.cc
+++ b/bess/core/modules/qos.cc
@@ -403,6 +403,11 @@ CommandResponse Qos::CommandAdd(const bess::pb::QosCommandAddArg &arg) {
 CommandResponse Qos::CommandDelete(const bess::pb::QosCommandDeleteArg &arg) {
   MeteringKey key;
   CommandResponse err = ExtractKey(arg, &key);
+
+  if (err.error().code() != 0) {
+    return err;
+  }
+
   table_.Delete(key);
   return CommandSuccess();
 }


### PR DESCRIPTION
A memory-safety fix rather than a reporting one, so it is separate from #1276 and #1277 even though
it lands in the same file as #1276. Independent of both; they touch `CommandAdd`, this touches
`CommandDelete`.

## The defect

```cpp
CommandResponse Qos::CommandDelete(const bess::pb::QosCommandDeleteArg &arg) {
  MeteringKey key;
  CommandResponse err = ExtractKey(arg, &key);
  table_.Delete(key);
  return CommandSuccess();
}
```

`ExtractKey()`'s result is assigned and never looked at. It returns `EINVAL` when the request's
field count does not match the module's -- and it returns **before** reaching its own
`memset(key, 0, sizeof(*key))`:

```cpp
CommandResponse Qos::ExtractKey(const T &arg, MeteringKey *key) {
  if ((size_t)arg.fields_size() != fields_.size()) {
    return CommandFailure(EINVAL, "must specify %zu masks", fields_.size());   // <- returns here
  }

  memset(key, 0, sizeof(*key));                                                 // <- never reached
```

`key` is a bare stack local, so on that path it is never written at all. The delete then runs
against an uninitialised key: indeterminate values, and a chance of removing an unrelated rule
whose key happens to match whatever the stack held.

`Qos::CommandAdd` checks the equivalent `ExtractKeyMask()` call already, and this change uses the
identical form. **Of the six command handlers across `Qos`, `ExactMatch` and `WildcardMatch`, this
was the only one not checking that the request could describe a key at all** -- so the intended
pattern was already established five times over.

To be precise about what that check is and is not: it verifies the *field count*, which is what
makes the uninitialised-key path unreachable. It is not validation of the key's contents, and the
contents are genuinely unvalidated elsewhere in this module -- `ExtractKeyMask` writes each field
into a two-byte `MKey` at the field's own offset, and both it and `ExtractKey` copy a `value_bin`
of any length into a `uint64_t`. Those are separate defects, they are pre-existing, and I will
raise them on their own rather than widen this diff.

## What is deliberately left alone

`table_.Delete()`'s own return is still discarded, and that is a decision rather than an oversight.
`Metering::Delete` reports `ENOENT "rule doesn't exist"` for a key that is not present, but on the
delete path an absent rule is **idempotency, not a refusal** -- a session teardown re-deletes rules
that may already be gone. Propagating it would be harmless today, since nothing consumes the
result, but it would become wrong the moment something does: a normal teardown would report a
failed delete, and in `pfcpiface` a rejected deletion keeps the session and never releases its
address. The new test pins that behaviour explicitly, next to the refusal it does assert.

## The test is this module's first automated coverage

Worth stating plainly, because it surprised me while writing it: **nothing in CI exercised `Qos`
before this.** `bessctl/run_module_tests.py` globs `*.py` (`--test_name` defaults to `*`), so the
six `.bess` files under `module_tests/` -- `metering.bess` among them -- are never run by it, and
no `.py` test touched `Qos` or `Metering`. That is not a regression; the glob has been `*.py` since
the source was integrated.

`module_tests/qos.py` follows the existing `BessModuleTestCase` shape and the
`with self.assertRaises(bess.Error):` idiom already used by `l2forward.py` and `iplookup.py`. It
builds the module with offset-based fields so it needs no metadata provider upstream of it.

## Verification

On linux/amd64 with the dependency list from `bess/env/build-dep.yml` (`./build.py bess`, system
DPDK 25.11.0), from a clean tree:

- **`run_module_tests.py --test_name qos`: ok.**
- **Mutation-verified, and this one mattered.** My first concern was that the test might pass for
  the wrong reason -- if `pybess` rejected the field count client-side, the `bess.Error` would come
  from the client and the test would pass with or without the fix. Removing the guard and rebuilding
  makes it fail with `AssertionError: Error not raised`, so the refusal genuinely comes from the
  module. Restoring the guard makes it pass again.
- **`all_test`: 187 of 188.** The single failure, `DmaMemoryPoolTest.PoolSetup`, is not from this
  change -- it reproduces on an unmodified `main` build, still fails with `--ulimit memlock=-1`, and
  wants a 1 GB hugepage this build host does not provide. `bess-source-tests` is green in CI on
  #1272, #1271 and #1268.
- `clang-format-14` (the version this repo pins for `bess/core`) reports `qos.cc` clean. Both files
  are free of trailing whitespace and end in a single newline, which is what the `whitespace` job
  checks. `bess/bessctl/module_tests/` is excluded from `ruff` by `.pre-commit-config.yaml`, so the
  new test is not subject to it.

