### PR TITLE
fix(bess): drop a dead mask copy that overflows its destination

### DIFF
--- a/bess/core/modules/qos.cc
+++ b/bess/core/modules/qos.cc
@@ -266,7 +266,7 @@ CommandResponse Qos::ExtractKey(const T &arg, MeteringKey *key) {
 
 template <typename T>
 CommandResponse Qos::ExtractKeyMask(const T &arg, MeteringKey *key,
-                                    MeteringKey *val, MKey *l) {
+                                    MeteringKey *val) {
   if ((size_t)arg.fields_size() != fields_.size()) {
     return CommandFailure(EINVAL, "must specify %zu masks", fields_.size());
   }
@@ -294,28 +294,6 @@ CommandResponse Qos::ExtractKeyMask(const T &arg, MeteringKey *key,
     }
 
     memcpy(reinterpret_cast<uint8_t *>(key) + field_pos, &k, field_size);
-  }
-
-  for (size_t i = 0; i < fields_.size(); i++) {
-    int field_size = fields_[i].size;
-    int field_pos = fields_[i].pos;
-
-    uint64_t k = 0;
-
-    bess::pb::FieldData fieldsdata = arg.fields(i);
-    if (fieldsdata.encoding_case() == bess::pb::FieldData::kValueInt) {
-      if (!bess::utils::uint64_to_bin(&k, fieldsdata.value_int(), field_size,
-                                      false)) {
-        return CommandFailure(EINVAL, "idx %zu: not a correct %d-byte mask", i,
-                              field_size);
-      }
-    } else if (fieldsdata.encoding_case() == bess::pb::FieldData::kValueBin) {
-      bess::utils::Copy(reinterpret_cast<uint8_t *>(&k),
-                        fieldsdata.value_bin().c_str(),
-                        fieldsdata.value_bin().size());
-    }
-
-    memcpy(reinterpret_cast<uint8_t *>(l) + field_pos, &k, field_size);
   }
 
   for (size_t i = 0; i < values_.size(); i++) {
@@ -349,10 +327,9 @@ CommandResponse Qos::CommandAdd(const bess::pb::QosCommandAddArg &arg) {
   }
   MeteringKey key = {{0}};
 
-  MKey l;
   value v;
   v.ogate = gate;
-  CommandResponse err = ExtractKeyMask(arg, &key, &v.Data, &l);
+  CommandResponse err = ExtractKeyMask(arg, &key, &v.Data);
 
   if (err.error().code() != 0) {
     return err;

--- a/bess/core/modules/qos.h
+++ b/bess/core/modules/qos.h
@@ -43,11 +43,6 @@ struct value {
   MeteringKey Data;
 };
 
-struct MKey {
-  uint8_t key1;
-  uint8_t key2;
-};
-
 class Qos final : public Module {
  public:
   static const gate_idx_t kNumOGates = MAX_GATES;
@@ -70,7 +65,7 @@ class Qos final : public Module {
       const bess::pb::QosCommandSetDefaultGateArg &arg);
   template <typename T>
   CommandResponse ExtractKeyMask(const T &arg, MeteringKey *key,
-                                 MeteringKey *val, MKey *l);
+                                 MeteringKey *val);
   template <typename T>
   CommandResponse ExtractKey(const T &arg, MeteringKey *key);
   CommandResponse AddFieldOne(const bess::pb::Field &field,


### PR DESCRIPTION
A memory-safety fix, independent of #1275 / #1276 / #1277 / #1278. It touches `qos.cc`, as #1276 and
#1278 do, but a different function.

## The defect

`Qos::ExtractKeyMask` runs the same loop over the module's fields **twice**. The two bodies are
byte-for-byte identical except for the destination of the final copy:

```cpp
    memcpy(reinterpret_cast<uint8_t *>(key) + field_pos, &k, field_size);   // first loop
...
    memcpy(reinterpret_cast<uint8_t *>(l) + field_pos, &k, field_size);     // second loop
```

`key` is a `MeteringKey` -- eight `uint64_t`, 64 bytes -- and `field_pos` is assigned by
`AddFieldOne` for that layout. `l` is an `MKey`:

```cpp
struct MKey {
  uint8_t key1;
  uint8_t key2;
};
```

Two bytes, written at offsets meant for a 64-byte object. `appQERLookup` is configured with fields
of 1, 4 and 8 bytes (`conf/up4.bess`), so their positions are 0, 1 and 5: **the second field writes
three bytes past the end of the struct and the third writes eleven.** Any `Qos.add()` carrying more
than one field overflows it, which in this deployment is every one.

AddressSanitizer, over the struct as declared and that field geometry, aborts on the *second* field
before reaching the third:

```
ERROR: AddressSanitizer: stack-buffer-overflow
WRITE of size 4 at 0x00016d2be242
Address 0x00016d2be242 is located in stack of thread T0 at offset 98 in frame
    [96, 98) 'l' <== Memory access at offset 98 overflows this variable
```

Reading that: `l` occupies frame offsets 96 and 97. The second field is four bytes at position 1,
so the copy starts at 97 and touches 97 through 100 — ASan's `memcpy` interceptor reports the
first byte that is *out of bounds*, which is 98, rather than where the access began. Bytes 98, 99
and 100 are the three past the end.

## Why the fix is a deletion rather than a bound

Nothing reads it. `MKey` has exactly two *uses* in the tree — the local in `CommandAdd` and the
parameter it is passed as — alongside its definition and declaration, so `git grep MKey` shows
four lines and no reader among them. `CommandAdd` passes it by address to `ExtractKeyMask` and
never looks at it again.
The second loop recomputes a value the first loop already derived, stores it where no one will read
it, and corrupts the stack doing so. Bounding the write would preserve dead work; removing it takes
the loop, the parameter, the local and the struct with it.

`ExtractKey` -- the sibling used by `CommandDelete` -- was never given an `MKey` and is unaffected.

## Behaviour

Unchanged, by construction: the deleted loop's only effect was the overflowing write. Its `k`
computation, its error returns and its field metadata are all identical to the loop that remains, so
no input reaches a different outcome.

## Verification

On linux/amd64 with the dependency list from `bess/env/build-dep.yml` (`./build.py bess`, system
DPDK 25.11.0), from a clean tree:

- **`all_test`: 188 tests from 51 suites, 187 pass.** That is the same total and the same suite count
  as an unmodified `main` build -- this change adds no tests, so an unchanged result is the point.
  The single failure, `DmaMemoryPoolTest.PoolSetup`, is not from this change: it reproduces on
  pristine `main`, still fails with `--ulimit memlock=-1`, and wants a 1 GB hugepage this build host
  does not provide. `bess-source-tests` is green in CI on #1272, #1271 and #1268.
- **`run_module_tests.py`: exit 0, 22 files, 0 failures.** Stated precisely: none of those tests
  touches `Qos` or `Metering`, so they show that nothing else regressed rather than exercising this
  path. The module has no automated coverage in-tree today; #1278 adds the first.
- `clang-format-14`, the version this repo pins for `bess/core`, reports both files clean.

I have not added a test here. The overflow is undefined behaviour rather than an observable result,
so a unit test could only assert the value nobody reads; the honest check is the sanitiser above,
and the argument that the loop is dead. If you would prefer this land with an ASan build wired into
CI instead, that is a larger and more useful change and I would rather raise it separately.

