### PR TITLE
fix(bess): bound the binary value copied into a key field

### DIFF
--- a/bess/bessctl/module_tests/wildcard_match.py
+++ b/bess/bessctl/module_tests/wildcard_match.py
@@ -176,6 +176,32 @@ class BessWildcardMatchTest(BessModuleTestCase):
         #    '\nmut state:', cur_config, 'expecting:', expect_config)
     #    assert arg == iconf and cur_config == expect_config
 
+    # Each field of a rule is assembled by copying its value_bin into a
+    # uint64_t. A value longer than that must be refused rather than written
+    # past it: Copy() is length-driven and the length comes from the request.
+    def test_wildcardmatch_refuses_an_oversized_binary_value(self):
+        wm = WildcardMatch(fields=[{'offset': 26, 'num_bytes': 4}])
+
+        # Nine bytes into eight.
+        with self.assertRaises(bess.Error):
+            wm.add(gate=0, priority=0,
+                   masks=vstring([0xff, 0xff, 0xff, 0xff]),
+                   values=vstring([0x01] * 9))
+
+        # The mask is assembled the same way and is checked the same way.
+        with self.assertRaises(bess.Error):
+            wm.add(gate=0, priority=0,
+                   masks=vstring([0xff] * 9),
+                   values=vstring([0x01, 0x02, 0x03, 0x04]))
+
+        # A value that fits is still accepted, and still zero-extended.
+        wm.add(gate=0, priority=0,
+               masks=vstring([0xff, 0xff, 0xff, 0xff]),
+               values=vstring([0x01, 0x02]))
+
+        self.assertBessAlive()
+
+
 suite = unittest.TestLoader().loadTestsFromTestCase(BessWildcardMatchTest)
 results = unittest.TextTestRunner(verbosity=2).run(suite)
 

--- a/bess/core/modules/exact_match.cc
+++ b/bess/core/modules/exact_match.cc
@@ -70,6 +70,11 @@ CommandResponse ExactMatch::AddFieldOne(const bess::pb::Field &field,
   if (mask.encoding_case() == bess::pb::FieldData::kValueInt) {
     mask64 = mask.value_int();
   } else if (mask.encoding_case() == bess::pb::FieldData::kValueBin) {
+    if (mask.value_bin().size() > sizeof(mask64)) {
+      return CommandFailure(EINVAL, "idx %d: mask is %zu bytes, at most %zu",
+                            idx, mask.value_bin().size(), sizeof(mask64));
+    }
+
     bess::utils::Copy(reinterpret_cast<uint8_t *>(&mask64),
                       mask.value_bin().c_str(), mask.value_bin().size());
   }

--- a/bess/core/modules/qos.cc
+++ b/bess/core/modules/qos.cc
@@ -254,6 +254,12 @@ CommandResponse Qos::ExtractKey(const T &arg, MeteringKey *key) {
                               field_size);
       }
     } else if (fieldsdata.encoding_case() == bess::pb::FieldData::kValueBin) {
+      if (fieldsdata.value_bin().size() > sizeof(k)) {
+        return CommandFailure(EINVAL,
+                              "idx %zu: binary value is %zu bytes, at most %zu",
+                              i, fieldsdata.value_bin().size(), sizeof(k));
+      }
+
       bess::utils::Copy(reinterpret_cast<uint8_t *>(&k),
                         fieldsdata.value_bin().c_str(),
                         fieldsdata.value_bin().size());
@@ -288,6 +294,12 @@ CommandResponse Qos::ExtractKeyMask(const T &arg, MeteringKey *key,
                               field_size);
       }
     } else if (fieldsdata.encoding_case() == bess::pb::FieldData::kValueBin) {
+      if (fieldsdata.value_bin().size() > sizeof(k)) {
+        return CommandFailure(EINVAL,
+                              "idx %zu: binary value is %zu bytes, at most %zu",
+                              i, fieldsdata.value_bin().size(), sizeof(k));
+      }
+
       bess::utils::Copy(reinterpret_cast<uint8_t *>(&k),
                         fieldsdata.value_bin().c_str(),
                         fieldsdata.value_bin().size());
@@ -309,6 +321,12 @@ CommandResponse Qos::ExtractKeyMask(const T &arg, MeteringKey *key,
                               val_size);
       }
     } else if (valuedata.encoding_case() == bess::pb::FieldData::kValueBin) {
+      if (valuedata.value_bin().size() > sizeof(v)) {
+        return CommandFailure(EINVAL,
+                              "idx %zu: binary value is %zu bytes, at most %zu",
+                              i, valuedata.value_bin().size(), sizeof(v));
+      }
+
       bess::utils::Copy(reinterpret_cast<uint8_t *>(&v),
                         valuedata.value_bin().c_str(),
                         valuedata.value_bin().size());

--- a/bess/core/modules/wildcard_match.cc
+++ b/bess/core/modules/wildcard_match.cc
@@ -436,6 +436,12 @@ CommandResponse WildcardMatch::ExtractKeyMask(const T &arg, wm_hkey_t *key,
                               field_size);
       }
     } else if (valuedata.encoding_case() == bess::pb::FieldData::kValueBin) {
+      if (valuedata.value_bin().size() > sizeof(v)) {
+        return CommandFailure(EINVAL,
+                              "idx %zu: binary value is %zu bytes, at most %zu",
+                              i, valuedata.value_bin().size(), sizeof(v));
+      }
+
       bess::utils::Copy(reinterpret_cast<uint8_t *>(&v),
                         valuedata.value_bin().c_str(),
                         valuedata.value_bin().size());
@@ -449,6 +455,12 @@ CommandResponse WildcardMatch::ExtractKeyMask(const T &arg, wm_hkey_t *key,
                               field_size);
       }
     } else if (maskdata.encoding_case() == bess::pb::FieldData::kValueBin) {
+      if (maskdata.value_bin().size() > sizeof(m)) {
+        return CommandFailure(EINVAL,
+                              "idx %zu: binary value is %zu bytes, at most %zu",
+                              i, maskdata.value_bin().size(), sizeof(m));
+      }
+
       bess::utils::Copy(reinterpret_cast<uint8_t *>(&m),
                         maskdata.value_bin().c_str(),
                         maskdata.value_bin().size());
@@ -494,6 +506,12 @@ CommandResponse WildcardMatch::ExtractValue(const T &arg, wm_hkey_t *keyv) {
                               value_size);
       }
     } else if (valuedata.encoding_case() == bess::pb::FieldData::kValueBin) {
+      if (valuedata.value_bin().size() > sizeof(v)) {
+        return CommandFailure(EINVAL,
+                              "idx %zu: binary value is %zu bytes, at most %zu",
+                              i, valuedata.value_bin().size(), sizeof(v));
+      }
+
       bess::utils::Copy(reinterpret_cast<uint8_t *>(&v),
                         valuedata.value_bin().c_str(),
                         valuedata.value_bin().size());


### PR DESCRIPTION
**Stacked on #1279** — please take that one first. It deletes a loop in `Qos::ExtractKeyMask` that
contains a fourth instance of the copy fixed here; bounding a line that another open PR removes
would be pointless, so this branch is based on it and fixes the three that survive. Rebasing onto
`main` alone is trivial if you would rather have them independent.

## The defect

`Qos` and `WildcardMatch` assemble each key, mask and value field by copying a `FieldData`'s
`value_bin` straight into a `uint64_t` local:

```cpp
      bess::utils::Copy(reinterpret_cast<uint8_t *>(&k),
                        fieldsdata.value_bin().c_str(),
                        fieldsdata.value_bin().size());
```

`Copy()` is length-driven and the length comes from the request, so a `value_bin` longer than eight
bytes writes past the local and smashes the stack of the command handler. **Seven sites do this:**
three in `qos.cc`, three in `wildcard_match.cc`, and `ExactMatch::AddFieldOne`'s mask
(`exact_match.cc:73`).

Nothing upstream bounds them. The int-encoded branch sitting immediately beside each one *is*
checked, by `uint64_to_bin()`. `ExactMatch` checks the equivalent copy for a *rule* in
`gather_key()` — but not the one for a *mask*, which is the seventh site:

```cpp
      if (static_cast<size_t>(field_size) != f_obj.size()) {
        return MakeError(EINVAL, Format("rule field %zu should have size %d (has %zu)", …));
      }
```

These seven took the length on trust. For completeness, the other two modules with this shape --
`GenericEncap` and `SetMetadata` -- already require an exact length match before copying, so they
are correct and untouched.

Reachable over the control socket, not from the datapath: `pfcpiface` only ever sends `value_int`.

## Why the bound is `sizeof()` and not the field width

`ExactMatch` requires an exact match against the field width. Doing that here would reject requests
that work today: a short `value_bin` is currently zero-extended, because the local is zero-initialised
and only `field_size` bytes are copied back out into the key afterwards. The field width is
therefore already applied at the right place, and narrowing this check to it would be a behaviour
change wearing a bounds-check costume.

So each site refuses only a value that cannot fit the destination, in the style the int-encoded
branch beside it already uses. Values that work today keep working, and the new test asserts that
direction explicitly.

## Test

`bessctl/module_tests/wildcard_match.py` gains
`test_wildcardmatch_refuses_an_oversized_binary_value`: nine bytes into eight is refused for a
value, the same for a mask, and a two-byte value is still accepted for a four-byte field.

**Mutation-verified.** With all six guards stripped the new test fails with `AssertionError: Error
not raised` and **the other three tests in that file still pass**, so it detects this defect and
nothing else.

One gap, stated rather than glossed: the test covers the two sites in `WildcardMatch::CommandAdd`.
The `valuesv` loop, the three in `Qos` and the new one in `ExactMatch::AddFieldOne` are the same
pattern fixed the same way but are not exercised — `Qos` has no module test in-tree at all (#1278
adds the first), and reaching `AddFieldOne`'s mask path needs a module built with a `value_bin`
mask, which `exact_match.py` does not do.

## Verification

On linux/amd64 with the dependency list from `bess/env/build-dep.yml` (`./build.py bess`, system
DPDK 25.11.0), from a clean tree:

- **`run_module_tests.py`: exit 0, 22 files, 0 failures**, the new test among them.
- **`all_test`: 188 tests, 187 pass.** The single failure, `DmaMemoryPoolTest.PoolSetup`, is not from
  this change: it reproduces on an unmodified build, still fails with `--ulimit memlock=-1`, and
  wants a 1 GB hugepage this host does not provide. `bess-source-tests` is green in CI on #1272,
  #1271 and #1268.
- `clang-format-14`, the version this repo pins for `bess/core`, reports both files clean; the two
  `.cc` files and the `.py` are free of trailing whitespace and end in a single newline.

