### PR TITLE
fix(pfcpiface): report a slice-meter command the datapath refused

### DIFF
--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -1518,15 +1518,18 @@ func (b *bess) processSliceMeter(ctx context.Context, arg *anypb.Any, method upf
 
 	methods := [...]string{upfMethodAdd, upfMethodAdd, upfMethodDelete, upfMethodClear}
 
-	_, err := b.client.ModuleCommand(
+	resp, err := b.client.ModuleCommand(
 		ctx, &pb.CommandRequest{
 			Name: "sliceMeter",
 			Cmd:  methods[method],
 			Arg:  arg,
 		},
 	)
-	if err != nil {
-		logger.BessLog.Errorln("sliceMeter method failed:", err)
+
+	logger.BessLog.Debugf("sliceMeter resp: %v", resp)
+
+	if err != nil || resp.GetError() != nil {
+		logger.BessLog.Errorf("sliceMeter method failed with resp: %v, err: %v", resp, err)
 	}
 }
 


### PR DESCRIPTION
Independent of #1275 / #1276 / #1277 / #1278 / #1279 / #1280 — different file, no overlap.

## The defect

`processSliceMeter` throws the response away and tests only the RPC error:

```go
	_, err := b.client.ModuleCommand(...)
	if err != nil {
		logger.BessLog.Errorln("sliceMeter method failed:", err)
	}
```

A module that refuses the command answers over a healthy connection: `err` is nil and the refusal
is carried in `resp.Error`, which is never looked at. So a `sliceMeter` add, delete or clear that
BESS declined leaves no trace at all.

Of the five `process*` helpers it is the only one that does this. `processPDR`, `processFAR` and
`processGtpuPathMonitoring` all test `resp.GetError()`, and `processQER` was given the same
treatment in #1230. This brings the last one into line, using the form the siblings already use.

`resp.GetError()` is nil-safe on a nil response, and `err != nil` short-circuits ahead of it in any
case.

## What this deliberately does not do

It does not give the helper an error return. Its callers — `AddSliceInfo` and `setupSliceMeter` —
only log what `GRPCJoin` reports, so a propagated error would have nowhere further to go today.
More to the point, making a callee report truthfully while the workers above it still derive their
result from their own progress is a change that has to move as one piece; doing it here piecemeal
is the ordering mistake this workstream has already paid for once. Logging at the point of refusal
puts the information where it is useful now, and does not foreclose plumbing it later.

## No test, and why

The helper returns nothing and only logs, so there is nothing a unit test could assert that the
unfixed version would not satisfy equally. Capturing `logger.BessLog` to assert on a log line would
mean reworking logging for a four-line change. The argument for correctness here is consistency:
the diff makes this helper identical in shape to three siblings in the same file.

## Verification

On linux/amd64 in CI's own images at CI's pinned versions:

- `go build ./...`, `go vet ./pfcpiface/` clean.
- CI's exact unit-test command, `go test -race -failfast ./pfcpiface ./cmd/...` — ok.
- CI's exact integration command, `MODE=native DATAPATH=bess go test -race -failfast -count=1
  ./test/integration/...` — ok.
- `golangci-lint` at the pinned v2.13.2: **0 issues**; `golangci-lint fmt --diff` empty.
