### PR TITLE
fix(bess): check the field count before reading per-field metadata

### DIFF
--- a/bess/core/modules/exact_match.cc
+++ b/bess/core/modules/exact_match.cc
@@ -234,6 +234,13 @@ Error ExactMatch::AddRule(const bess::pb::ExactMatchCommandAddArg &arg) {
   memset(&t.action, 0, sizeof(t.action));
   /* set gate */
   t.gate = gate;
+  /* check whether the fields match the table's, before reading per-field
+   * metadata indexed by the request's own count */
+  if (arg.fields_size() != (ssize_t)table_.num_fields())
+    return std::make_pair(
+        EINVAL, bess::utils::Format(
+                    "rule has incorrect number of fields. Need %d, has %d",
+                    (int)table_.num_fields(), arg.fields_size()));
   RuleFieldsFromPb(arg.fields(), &rule, FIELD_TYPE);
   /* check whether values match with the the table's */
   if (arg.values_size() != (ssize_t)num_values())
@@ -409,6 +416,12 @@ CommandResponse ExactMatch::CommandDelete(
 
   if (arg.fields_size() == 0) {
     return CommandFailure(EINVAL, "argument must be a list");
+  }
+
+  if (arg.fields_size() != (ssize_t)table_.num_fields()) {
+    return CommandFailure(
+        EINVAL, "rule has incorrect number of fields. Need %d, has %d",
+        (int)table_.num_fields(), arg.fields_size());
   }
 
   ExactMatchRuleFields rule;


### PR DESCRIPTION
Independent of #1275 / #1276 / #1277 / #1278 / #1279 / #1280 / #1281 — different file, no overlap.

## The defect

`RuleFieldsFromPb` walks the request's fields and, for each, reads the table's metadata at that
index:

```cpp
  for (auto i = 0; i < fields.size(); i++) {
    int field_size =
        (type == FIELD_TYPE) ? table_.get_field(i).size : get_value(i).size;
```

`get_field()` and `get_value()` are bare array accesses:

```cpp
  const ExactMatchField &get_field(size_t i) const { return fields_[i]; }
```

`fields_` and `values_` are `ExactMatchField[MAX_FIELDS]`, MAX_FIELDS being 8, and the loop is
bounded by the **request's** field count rather than the table's. So a rule carrying more fields
than the table has reads metadata the table does not own. Both arrays are value-initialised, so a
count between `num_fields_` and MAX_FIELDS reads zeroed entries -- meaningless but harmless. Beyond
8 it reads past the end of the array.

**Two of the three call sites had nothing in front of them.** The values path already does the right
thing, three lines below the first one:

```cpp
  if (arg.values_size() != (ssize_t)num_values())
    return std::make_pair(EINVAL, …);
```

`AddRule`'s fields path had no such check, and `CommandDelete` verified only that the list was
non-empty. Both now compare against `table_.num_fields()` before the call, in the style the values
path already established.

## Same errno, earlier, and one message differs

`gather_key()` already rejects a mismatched count with EINVAL, so a rule like this was refused
either way -- it was refused *after* the out-of-bounds read rather than before it. Nothing that
worked starts failing, and nothing that failed starts working.

To be exact rather than to claim more than that: the rejection text changes. It used to come from
`gather_key()` as `"rule should have %zu fields (has %zu)"` and now comes from these checks as
`"rule has incorrect number of fields. Need %d, has %d"`. Same errno, same refusal, different
wording -- worth knowing if anything greps for it.

That is also why there is no new test: one would pass with or without this change, so it would
assert nothing about the fix. What the existing `bessctl/module_tests/exact_match.py` does
establish is the other half of the claim -- it drives both guarded paths with matching counts, so
valid rules are still accepted. That suite passes.

If you would rather see this caught mechanically, the useful change is an ASan build in CI, which
would find this class rather than this instance. Happy to raise that separately; it is a bigger
change than this one.

## Verification

On linux/amd64 with the dependency list from `bess/env/build-dep.yml` (`./build.py bess`, system
DPDK 25.11.0), from a clean tree:

- **`run_module_tests.py`: exit 0, 22 files, 0 failures**, `exact_match.py` among them.
- **`all_test`: 188 tests, 187 pass.** The single failure, `DmaMemoryPoolTest.PoolSetup`, is not from
  this change: it reproduces on an unmodified build, still fails with `--ulimit memlock=-1`, and
  wants a 1 GB hugepage this host does not provide. `bess-source-tests` is green in CI on #1272,
  #1271 and #1268.
- `clang-format-14`, the version this repo pins for `bess/core`, reports the file clean.

