### PR TITLE
fix(bess): report a table that could not be created

### DIFF
--- a/bess/core/modules/exact_match.cc
+++ b/bess/core/modules/exact_match.cc
@@ -141,7 +141,10 @@ CommandResponse ExactMatch::Init(const bess::pb::ExactMatchArg &arg) {
   }
 
   default_gate_ = DROP_GATE;
-  table_.Init(arg.entries());
+  if (const Error err = table_.Init(arg.entries()); err.first != 0) {
+    return CommandFailure(err.first, "%s", err.second.c_str());
+  }
+
   return CommandSuccess();
 }
 

--- a/bess/core/modules/qos.cc
+++ b/bess/core/modules/qos.cc
@@ -101,7 +101,12 @@ CommandResponse Qos::Init(const bess::pb::QosArg &arg) {
     cs[i] = 0xff;
   }
 
-  table_.Init(total_key_size_, arg.entries());
+  if (const bess::utils::Error err =
+          table_.Init(total_key_size_, arg.entries());
+      err.first != 0) {
+    return CommandFailure(err.first, "%s", err.second.c_str());
+  }
+
   return CommandSuccess();
 }
 

--- a/bess/core/utils/cuckoo_map.h
+++ b/bess/core/utils/cuckoo_map.h
@@ -80,12 +80,18 @@ template <typename K, typename V, typename H = std::hash<K>,
 class CuckooMap {
  private:
   bool IsDpdk = false;
+  bool dpdk_init_failed_ = false;
   uint32_t key_len = 0;
   rte_hash_parameters rt;
 
  public:
   struct rte_hash* hash = nullptr;
   typedef std::pair<K, V> Entry;
+
+  // True when a DPDK-backed table was asked for and rte_hash_create() refused
+  // it. Such a map holds no table: every insert reports a failure and every
+  // lookup misses.
+  bool dpdk_init_failed() const { return dpdk_init_failed_; }
 
   class iterator {
    public:
@@ -169,8 +175,13 @@ class CuckooMap {
       if (hash == NULL) {
         rt = *((rte_hash_parameters*)dpdk_params);
         hash = rte_hash_create(&rt);
-        if (hash == NULL)
+        if (hash == NULL) {
+          // No table was created, so this map cannot serve the mode it was
+          // asked for. IsDpdk stays false, which is indistinguishable from a
+          // deliberately non-DPDK map, so record the failure separately.
+          dpdk_init_failed_ = true;
           return;
+        }
       }
       IsDpdk = true;
     } else {

--- a/bess/core/utils/exact_match_table.h
+++ b/bess/core/utils/exact_match_table.h
@@ -341,7 +341,8 @@ class ExactMatchTable {
 
   typename EmTable::iterator end() { return table_->end(); }
 
-  void Init(uint32_t entries) {
+  // Returns 0 on success, non-zero errno if no table could be created.
+  Error Init(uint32_t entries) {
     std::ostringstream address;
     address << &table_;
     std::string name = "Exactmatch" + address.str();
@@ -353,6 +354,12 @@ class ExactMatchTable {
     table_.reset(
         new CuckooMap<ExactMatchKey, T, ExactMatchKeyHash, ExactMatchKeyEq>(
             0, 0, &dpdk_params));
+
+    if (table_->dpdk_init_failed()) {
+      return MakeError(ENOMEM, "rte_hash_create() failed");
+    }
+
+    return MakeError(0);
   }
 
  private:

--- a/bess/core/utils/metering.h
+++ b/bess/core/utils/metering.h
@@ -169,7 +169,8 @@ class Metering {
 
   uint32_t Total_key_size() const { return total_key_size_; }
 
-  void Init(int size, int entries) {
+  // Returns 0 on success, non-zero errno if no table could be created.
+  Error Init(int size, int entries) {
     std::ostringstream address;
     total_key_size_ = size;
     address << &table_;
@@ -181,6 +182,12 @@ class Metering {
     dpdk_params.key_len = size;
     table_.reset(new CuckooMap<MeteringKey, T, MeteringKeyHash, MeteringKeyEq>(
         0, 0, &dpdk_params));
+
+    if (table_->dpdk_init_failed()) {
+      return MakeError(ENOMEM, "rte_hash_create() failed");
+    }
+
+    return MakeError(0);
   }
 
  private:


### PR DESCRIPTION
Independent of the other open PRs from me. It touches `qos.cc` and `exact_match.cc`, as some of
those do, but different functions.

## The defect

`CuckooMap`'s constructor gives up quietly when `rte_hash_create()` refuses a DPDK-backed table:

```cpp
    if (dpdk_params) {
      if (hash == NULL) {
        rt = *((rte_hash_parameters*)dpdk_params);
        hash = rte_hash_create(&rt);
        if (hash == NULL)
          return;          // <- no table, and nothing said
      }
      IsDpdk = true;
    }
```

It returns without setting `IsDpdk` — and `IsDpdk == false` is also exactly how a deliberately
non-DPDK map looks, so **no caller can tell the two apart**. `Metering::Init` and
`ExactMatchTable::Init` return `void`, so `Qos::Init` and `ExactMatch::Init` go on to answer
`CommandSuccess`.

The result is a module that is configured, attached to the pipeline, and holds no table at all:
every insert fails and every lookup misses, silently.

## The fix

- `CuckooMap` records that case separately from the mode it ended up in, via a `dpdk_init_failed()`
  accessor. Checking `IsDpdk` would not do — that is the ambiguity above.
- `Metering::Init` and `ExactMatchTable::Init` return the `Error` type their own files already use
  for this (`MakeError`), instead of `void`.
- `Qos::Init` and `ExactMatch::Init` report the failure rather than claiming success, in the style
  those files already use for other `Init` failures.

## Why this matters beyond the silence

It is the root of a confusing errno on the insert path. `insert_dpdk()` returns `-1` when there is
no table, which propagates as `EPERM` — "operation not permitted" — rather than anything about the
table's absence. I noted that wrinkle in #1276 when bounding a different defect. Failing at
creation is where the condition belongs; once that reports, the insert-path errno is a detail
rather than the only signal anyone gets.

`ENOMEM` is used for the failure. `rte_hash_create()` sets `rte_errno` with a better reason —
`EEXIST` for a name collision, `ENOMEM` for memory, `EINVAL` for bad parameters — and forwarding
that would be an improvement. I left it out to keep this change on the reporting path; happy to add
it here or separately if you would prefer the specific cause.

## No new test

The failure needs `rte_hash_create()` to refuse, which in a unit test means either exhausting
hugepage memory or forcing a name collision — both fragile and both liable to leave DPDK state
behind for whatever test runs next. The existing suites are the useful check in the other
direction: they show that the success path still reports success and that nothing regressed.

Two of the tests in `exact_match_table_test.cc` do exercise this code with a table that fails to
create, incidentally, because they run before DPDK is up. That is the subject of #1277 and is not
changed here.

## One knock-on, if this and my other PRs both land

#1276 and #1277 each add a test fixture whose comment says that when `rte_hash_create()` fails,
`CuckooMap` "stays in its non-DPDK mode without saying so" / "without reporting that". That is
true today and becomes false once this lands — the whole point here is that it does say so. The
comments describe why those tests must bring DPDK up themselves, which stays valid either way; only
that clause goes stale.

I have deliberately not force-pushed those two PRs to reword a comment clause, since both are green
and have been for a while. Flagging it here instead, at the point where the drift is created:
whoever merges last can drop the clause, or I will follow up.

## Verification

On linux/amd64 with the dependency list from `bess/env/build-dep.yml` (`./build.py bess`, system
DPDK 25.11.0), from a clean tree:

- **`run_module_tests.py`: exit 0, 22 files, 0 failures.**
- **`all_test`: 188 tests, 187 pass.** The single failure, `DmaMemoryPoolTest.PoolSetup`, is not
  from this change: it reproduces on an unmodified build, still fails with `--ulimit memlock=-1`,
  and wants a 1 GB hugepage this host does not provide. `bess-source-tests` is green in CI on
  #1272, #1271 and #1268.
- `clang-format-14`, the version this repo pins for `bess/core`, reports all five files clean.

