### PR TITLE
fix(bess): free a wildcard rule the table refused

### DIFF
--- a/bess/core/modules/wildcard_match.cc
+++ b/bess/core/modules/wildcard_match.cc
@@ -608,8 +608,15 @@ CommandResponse WildcardMatch::CommandAdd(
   }
   struct WmData *data_t = new WmData(data);
   int ret = tuples_[idx].ht->insert_dpdk(&key, data_t);
-  if (ret < 0)
+  if (ret < 0) {
+    // The insert failed, so no lookup can return this pointer. Values the
+    // table did take are a different matter and are left alone: commands here
+    // are THREAD_SAFE and run while ProcessBatch dereferences what a lookup
+    // returned.
+    delete data_t;
     return CommandFailure(EINVAL, "failed to add a rule");
+  }
+
   return CommandSuccess();
 }
 


### PR DESCRIPTION
Independent of my other open PRs. It touches `wildcard_match.cc`, as #1280 does, but a different
function — I merged both onto `main` in a scratch worktree to check, and it is clean with both
changes present.

## The defect

`CommandAdd` allocates the rule's value before offering it to the tuple's table, and returns
without freeing it when the table says no:

```cpp
  struct WmData *data_t = new WmData(data);
  int ret = tuples_[idx].ht->insert_dpdk(&key, data_t);
  if (ret < 0)
    return CommandFailure(EINVAL, "failed to add a rule");
```

`insert_dpdk()` returns negative when the tuple's table has no room, so this is reachable rather
than theoretical, and every refused add leaks one `WmData`.

## Why freeing is safe here

Because the insert *failed*: no lookup can return a pointer the table did not take.

That is deliberately narrower than "nothing else can be holding it", which is what I first wrote.
The property the free depends on is that the value was never published by the table, and that holds
regardless of what `rte_cuckoo_hash` does with its key store on the way to reporting the failure.

The distinction matters, because this file also holds values that must **not** be freed. This
module's own `add`, `delete` and `clear` are declared `Command::THREAD_SAFE` at
`wildcard_match.cc:83` onwards, which `commands.h` defines as "workers don't need to be paused in
order to run this command" — so they run concurrently with `ProcessBatch`, which dereferences the
pointers a lookup returned. (`set_runtime_config` in the same table is `THREAD_UNSAFE`, so the
distinction is used deliberately here.) DPDK says the same of a replaced value: "The readers might
still be using the old value even after this API has returned." Freeing a value the table is still
publishing would be a use-after-free; freeing one it refused is not.

`AddTuple`, the only other allocation in this file, already frees on its own failure path — and it
does so by testing `temp->hash == 0`, which is the only caller-side check in the tree that a table
was actually created (the subject of #1283).

### What this deliberately does not fix

Three sibling leaks in the same file are on the wrong side of that line and are left alone:
re-adding an existing key replaces the stored pointer and leaks the previous `WmData` on the
success path of this same function; `Clear()` and `AddTuple`'s replacement free the map and not the
values inside it; and `DelEntry` leaks the removed one. Each needs a grace period before the free —
DPDK offers `rte_hash_rcu_qsbr_add` for exactly this — and none can be fixed by freeing at the call
site. Naming them so it is clear the omission is a judgement rather than an oversight.

## No test

A leak is not observable through the module's interface; it needs a sanitiser. The failure path
itself is reachable by filling a tuple's table, but a test that did so would assert the refusal,
which already worked, and say nothing about the free. Adding an ASan build to CI would catch this
class rather than this instance, and is worth doing separately.

## Verification

On linux/amd64 with the dependency list from `bess/env/build-dep.yml` (`./build.py bess`, system
DPDK 25.11.0), from a clean tree:

- **`run_module_tests.py`: exit 0, 22 files, 0 failures**, `wildcard_match.py` among them.
- **`all_test`: 188 tests, 187 pass.** The single failure, `DmaMemoryPoolTest.PoolSetup`, is not
  from this change: it reproduces on an unmodified build, still fails with `--ulimit memlock=-1`,
  and wants a 1 GB hugepage this host does not provide. `bess-source-tests` is green in CI on
  #1272, #1271 and #1268.
- `clang-format-14`, the version this repo pins for `bess/core`, reports the file clean.

