### PR TITLE
fix(pfcpiface): release the UE address of a rejected session

### DIFF
--- a/pfcpiface/messages_session.go
+++ b/pfcpiface/messages_session.go
@@ -176,7 +176,34 @@ func (pConn *PFCPConn) handleSessionEstablishmentRequest(msg message.Message) (m
 
 	cause := upf.SendMsgToUPF(upfMsgTypeAdd, session.PacketForwardingRules, updated)
 	if cause == ie.CauseRequestRejected {
+		// The batch reported a failure, which means it completed and some of its rules
+		// may be programmed. Take them out before forgetting the session: nothing else
+		// will, because the session is never stored on this path and the SMF has no
+		// F-SEID to release. Best effort -- a datapath that just refused a write may
+		// refuse this one too, and there is nothing further to report it to.
+		if delCause := upf.SendMsgToUPF(
+			upfMsgTypeDel, session.PacketForwardingRules, PacketForwardingRules{},
+		); delCause == ie.CauseRequestRejected {
+			// Not yet evidence of a stranded rule, so this is not an error. The only
+			// things that can fail a BESS delete worker today are translating the rule
+			// (`CreatePortRangeCartesianProduct`) and marshalling it: `processPDR` and
+			// `processFAR` are void and `delQER` drops `processQER`'s error, so a module's
+			// refusal to delete cannot reach here. A rule that could not be translated
+			// was never programmed either -- which is exactly what happens when the add
+			// was refused for that same reason.
+			logger.PfcpLog.Warnln("the rollback of a rejected session reported a failure; " +
+				"no rule is known to be stranded")
+		}
+
+		// Parsing allocated the UE address (parse_pdr.go), and only the deletion path
+		// releases it. Without this, every rejected establishment leaks one address
+		// against a local SEID nobody will present again.
+		if relErr := releaseAllocatedIPs(upf.ippool, &session); relErr != nil {
+			logger.PfcpLog.Errorln("failed to release the IP of a rejected session:", relErr)
+		}
+
 		pConn.RemoveSession(session)
+
 		return errProcessReply(ErrWriteToDatapath,
 			ie.CauseRequestRejected)
 	}

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -579,3 +579,149 @@ func testUEAttachDetach(t *testing.T, testcase *testCase) {
 	testUEAttach(t, testcase)
 	testUEDetach(t, testcase)
 }
+
+// A session whose rule the datapath refuses must not leave its UE address allocated.
+//
+// Parsing allocates the address (parse_pdr.go's LookupOrAllocIP) before any rule is
+// programmed, and only the deletion path releases it -- so a rejected establishment
+// used to lose one address for good, against a local SEID nobody presents again.
+//
+// The assertion is capacity, which is the only thing that distinguishes released from
+// leaked here. DeallocIP returns an address to the *back* of the free queue while
+// LookupOrAllocIP takes from the front, so "the next session gets the address the
+// refused one held" is false either way. With a pool of exactly two addresses, a
+// refusal that releases leaves room for two more sessions; one that leaks leaves room
+// for one.
+//
+// The refusal is arranged with an SDF filter carrying a port range 101 wide.
+// CreatePortRangeCartesianProduct declines it, because asComplexTernaryMatches(Exact)
+// covers a range with one ternary rule per port and refuses anything wider than 100 --
+// so addPDR reports a failure before it makes an RPC, the batch completes having
+// refused, and SendMsgToUPF answers rejected. That is what makes it the refusal to test
+// with: it is decided client-side, so it needs no datapath fault.
+//
+// Both ports carry a range because parseSDFFilter's SDF workaround keeps only one of
+// them, and the filter does not get to choose which. The workaround tests one fixed side
+// per source interface -- the destination for core, the source for access, which that
+// case has already swapped -- and when the tested side holds a range it copies that
+// range onto the other side and becomes a wildcard itself, discarding whatever range the
+// other side held. So the pair never reaches the datapath as a pair, and a wide range on
+// each side leaves the survivor wide either way.
+func TestUeIPIsReleasedWhenTheDatapathRefusesTheSession(t *testing.T) {
+	setup(t, ConfigUPFBasedIPAllocationTinyPool)
+	defer teardown(t)
+
+	const aPortRangeTooWideToProgram = "permit out udp from any 100-200 to assigned 300-400"
+
+	// The uplink PDR carries the filter the datapath will refuse; the downlink one
+	// carries the CHOOSE flag that makes the UPF allocate an address.
+	allocatingDownlinkPDR := func() *ie.IE {
+		return ie.NewCreatePDR(
+			ie.NewPDRID(2),
+			ie.NewPrecedence(0),
+			ie.NewPDI(
+				ie.NewSourceInterface(ie.SrcInterfaceCore),
+				ie.NewUEIPAddress(0x10, "", "", 0, 0),
+				ie.NewSDFFilter(sdfFilterUDP80, "", "", "", 1),
+			),
+			ie.NewFARID(2),
+			ie.NewQERID(2),
+		)
+	}
+
+	fars := []*ie.IE{
+		session.NewFARBuilder().
+			WithMethod(session.Create).WithID(1).WithDstInterface(ie.DstInterfaceCore).
+			WithAction(ActionForward).BuildFAR(),
+		session.NewFARBuilder().
+			WithMethod(session.Create).WithID(2).
+			WithDstInterface(ie.DstInterfaceAccess).
+			WithAction(ActionDrop).WithTEID(16).
+			WithDownlinkIP(nodeBAddress).BuildFAR(),
+	}
+
+	uplinkPDR := func(filter string) *ie.IE {
+		return session.NewPDRBuilder().MarkAsUplink().
+			WithMethod(session.Create).WithID(1).WithTEID(15).
+			WithN3Address(upfN3Address).
+			WithSDFFilter(filter).
+			WithFARID(1).
+			AddQERID(1).BuildPDR()
+	}
+
+	establish := func(t *testing.T, filter string) (uint8, uint64) {
+		t.Helper()
+
+		pdrs := []*ie.IE{uplinkPDR(filter), allocatingDownlinkPDR()}
+		if err := pfcpClient.SendSessionEstablishmentRequest(pdrs, fars, nil, nil); err != nil {
+			t.Fatalf("establishment request failed to send: %v", err)
+		}
+
+		resp, err := pfcpClient.PeekNextResponse()
+		if err != nil {
+			t.Fatalf("no response to the establishment: %v", err)
+		}
+
+		estResp, ok := resp.(*message.SessionEstablishmentResponse)
+		if !ok {
+			t.Fatalf("expected a SessionEstablishmentResponse, got %T", resp)
+		}
+
+		cause, err := estResp.Cause.Cause()
+		if err != nil {
+			t.Fatalf("the establishment carried no readable cause: %v", err)
+		}
+
+		// A rejected establishment carries no UP F-SEID.
+		var upfSEID uint64
+
+		if estResp.UPFSEID != nil {
+			fseid, err := estResp.UPFSEID.FSEID()
+			if err != nil {
+				t.Fatalf("the establishment carried an unreadable UP F-SEID: %v", err)
+			}
+
+			upfSEID = fseid.SEID
+		}
+
+		return cause, upfSEID
+	}
+
+	// The refused session takes one of the two addresses and must give it back.
+	if cause, _ := establish(t, aPortRangeTooWideToProgram); cause != ie.CauseRequestRejected {
+		t.Fatalf("a session whose rule the datapath refused was answered with cause %d, want CauseRequestRejected (%d)",
+			cause, ie.CauseRequestRejected)
+	}
+
+	// It must also leave nothing of itself behind. The refused session is the only
+	// one so far, so an empty datapath means the rollback removed every rule the
+	// batch had programmed before it was refused.
+	verifyNoEntries(t)
+
+	// Both remaining establishments must find an address. Without the release the
+	// second has none, because the refused session is still holding one of the two.
+	seids := make([]uint64, 0, 2)
+
+	for i := 1; i <= 2; i++ {
+		cause, seid := establish(t, sdfFilterUDP80)
+		if cause != ie.CauseRequestAccepted {
+			t.Fatalf("session %d of 2 after a refused one was answered with cause %d, want CauseRequestAccepted (%d); "+
+				"the refused session did not release its address",
+				i, cause, ie.CauseRequestAccepted)
+		}
+
+		seids = append(seids, seid)
+	}
+
+	for _, seid := range seids {
+		if err := pfcpClient.SendSessionDeletionRequest(0, seid); err != nil {
+			t.Fatalf("deletion request failed to send: %v", err)
+		}
+
+		if _, err := pfcpClient.PeekNextResponse(); err != nil {
+			t.Fatalf("no response to the deletion: %v", err)
+		}
+	}
+
+	verifyNoEntries(t)
+}

--- a/test/integration/conf.go
+++ b/test/integration/conf.go
@@ -13,11 +13,20 @@ import (
 const (
 	ConfigDefault = iota
 	ConfigUPFBasedIPAllocation
+	// A pool holding exactly two usable addresses, so that whether a rejected
+	// session released its address is observable as capacity. With the /16 pool
+	// it is not: DeallocIP returns an address to the back of the free queue while
+	// allocation takes from the front, so the next session gets the next address
+	// either way.
+	ConfigUPFBasedIPAllocationTinyPool
 )
 
 const (
 	UEPoolUPF = "10.250.0.0/16"
-	UEPoolCP  = "17.0.0.0/16"
+	// /30 is four addresses; NewIPPool drops the network and broadcast ones, so
+	// this yields exactly .1 and .2.
+	UEPoolUPFTiny = "10.251.0.0/30"
+	UEPoolCP      = "17.0.0.0/16"
 )
 
 var baseConfig = pfcpiface.Conf{
@@ -56,12 +65,24 @@ func BESSConfigUPFBasedIPAllocation() pfcpiface.Conf {
 	return config
 }
 
+func BESSConfigUPFBasedIPAllocationTinyPool() pfcpiface.Conf {
+	config := BESSConfigDefault()
+	config.CPIface = pfcpiface.CPIfaceInfo{
+		EnableUeIPAlloc: true,
+		UEIPPool:        UEPoolUPFTiny,
+	}
+
+	return config
+}
+
 func GetConfig(configType uint32) pfcpiface.Conf {
 	switch configType {
 	case ConfigDefault:
 		return BESSConfigDefault()
 	case ConfigUPFBasedIPAllocation:
 		return BESSConfigUPFBasedIPAllocation()
+	case ConfigUPFBasedIPAllocationTinyPool:
+		return BESSConfigUPFBasedIPAllocationTinyPool()
 	}
 
 	panic("wrong datapath or config type provided")


### PR DESCRIPTION
A session establishment the datapath rejects leaks the UE IP address it was
given.

`parsePDR` allocates the address (`LookupOrAllocIP`) before any rule reaches
the datapath. Only the deletion path releases it. When `SendMsgToUPF` answers
`CauseRequestRejected`, `handleSessionEstablishmentRequest` removes the session
and returns — so the allocation stays, keyed to a local SEID that nobody will
ever present again, and nothing else can clean up after it: the session is
never stored on this path, and the SMF has no F-SEID to release. With UPF-based
allocation the pool loses one address per rejected establishment until it is
empty.

This releases the address, and takes the rules back out with the same delete
the session-deletion path uses. On establishment that is unambiguous: every
rule in the batch is new, so deleting the set is exactly undoing the add. Both
steps are best effort — a datapath that has just refused a write may refuse
this one too, and there is nothing further to report it to, so each logs and
carries on.

The rollback's own failure is logged at Warn rather than Error, because it is
not yet evidence of anything. The only things that can fail a delete worker
today are translating the rule and marshalling it: `processPDR` and
`processFAR` return nothing and `delQER` discards `processQER`'s error, so a
module's refusal to delete cannot reach the caller. And a rule that could not
be translated was never programmed either — which is precisely the case the
test exercises, where the same untranslatable PDR is what got the add refused.

### Left alone deliberately

- **The session deletion path.** A rejected delete leaves the datapath holding
  more than the store believes, which is the safe direction; rolling it back
  would mean re-adding rules the SMF asked to remove.
- **The modification path.** Its rejection cannot be undone by deleting what it
  programmed. `updated` mixes `CreatePDR/FAR/QER` with `UpdatePDR/FAR/QER`, and
  the update-derived entries carry the IDs of rules that already exist —
  `delFAR` keys on `(farID, fseID)`, so deleting them removes the live rules
  outright rather than restoring their previous version, leaving the datapath
  with less than the store describes. Undoing it properly needs the
  pre-modification rules, and the handler no longer has them: `PFCPSession`
  embeds `PacketForwardingRules`, whose `pdrs`/`fars`/`qers` are slices, so
  `UpdatePDR`'s `s.pdrs[idx] = p` writes through the backing array the store
  shares and the old values are gone before the write is attempted. That wants
  its own change.
- **The parse-failure returns earlier in the same handler.** A
  `CreatePDR`/`CreateFAR`/`CreateQER` that fails to parse is also answered
  rejected, and an address allocated by a PDR parsed before it leaks the same
  way. That is a malformed control-plane message rather than a datapath
  refusal, and the rollback it needs is a different one: `parsePDI` allocates
  before the PDR can fail, and such a PDR is never appended to `session.pdrs`,
  so the release has to be keyed by SEID rather than found in the session. It
  wants its own change and its own test.
- **A timed-out batch, here as everywhere.** `GRPCJoin` reports a timeout as
  not-completed and `SendMsgToUPF` answers accepted for that, so a rollback
  that times out reads as successful and the address is released while rules
  may still be in flight. The deletion path has had this shape all along;
  narrowing it means changing what a timeout means to every caller, which is
  not this change. The exposure is bounded in the meantime: `DeallocIP` returns
  the address to the back of the free queue and `LookupOrAllocIP` takes from
  the front, so the whole pool cycles before a released address is handed out
  again.

Two pre-existing leaks on the same handler are also untouched: a UPF-allocated
F-TEID is never freed on any path — `FreeID` has no caller outside its own
test — and `session.metrics` is not deleted on the parse-failure returns.

Two more sites drop a session without releasing its address, both outside this
handler and both left for their own change: the `CauseSessionContextNotFound`
branch of the session-report response, which deletes the session locally, and
`executeShutdown`, which clears every session on the connection. The pool
outlives a `PFCPConn` — it is built once in `SetUpfInfo` — so the second one
loses the whole pool across a PFCP association restart.

### The test

`TestUeIPIsReleasedWhenTheDatapathRefusesTheSession` pins both halves. After
the refusal it asserts the datapath is empty, which is what shows the rules
were taken back out; the refused session is the only one at that point, so
nothing else could account for the entries.

Then it asserts **capacity**, because capacity is the only thing here that
distinguishes released from leaked: `DeallocIP` returns an address to the back
of the free queue while `LookupOrAllocIP` takes from the front, so the next
session receives the next address either way. Against a pool of exactly two
addresses, a refusal that releases leaves room for two more sessions; one that
leaks leaves room for one. `ConfigUPFBasedIPAllocationTinyPool`
(`10.251.0.0/30`, which `NewIPPool` reduces to `.1` and `.2`) is that pool, and
its comment says why.

The refusal needs no datapath fault: an SDF filter carrying a port range 101
ports wide is declined by `CreatePortRangeCartesianProduct`, because
`asComplexTernaryMatches(Exact)` covers a range with one ternary rule per port
and refuses anything wider than 100. `addPDR` reports the failure without making
an RPC and the batch completes having refused.

The filter carries a wide range on *both* ports, but not because two ranges are
themselves refused. `parseSDFFilter`'s SDF workaround keeps only one of them,
and the filter does not get to choose which: it tests one fixed side per source
interface — the destination for core, the source for access, which that case has
already swapped — and when the tested side holds a range it copies that range
onto the other side and becomes a wildcard itself, discarding whatever the other
side held. So the pair never reaches the datapath as a pair, and a wide range on
each side leaves the survivor wide either way. `permit out udp from any to
assigned 300-400` reaches the same refusal; carrying both makes the test
independent of which side survives.

An earlier revision of this description said the refusal was the pair of ranges.
`CreatePortRangeCartesianProduct` does refuse `src.isRangeMatch() &&
dst.isRangeMatch()`, but that guard is unreachable from an SDF filter, for the
reason above. Copilot spotted the normalization; the refusal is the width.

This scenario logs the rollback's Warn on every run, in CI too: `delPDR` runs
the same `CreatePortRangeCartesianProduct` as `addPDR`, so the rule that could
not be translated for the add cannot be translated for the delete either, and
the delete batch reports rejected having removed every rule the add did program.
That is the case the Warn's comment describes.

### Verification

Each half was shown to fail against the pre-change code, independently:

- without the delete — `Expected no PDR entries, but found 1`
- without the release — `session 2 of 2 after a refused one was answered with cause 64, want CauseRequestAccepted (1); the refused session did not release its address`

`pre-commit run --all-files` clean, all 12 hooks (gitleaks, ruff-check,
ruff-format, clang-format, gci, staticcheck, `go test -race`,
golangci-lint-full v2.13.2, yamlfmt, end-of-file-fixer, trailing-whitespace,
reuse v6.2.0), run in `golang:1.26.0-bookworm` on linux/amd64 — the Go hooks do
not run on darwin, where `test/integration` cannot bind 127.0.0.8. Integration
suite `ok github.com/omec-project/upf-epc/test/integration`.

