### PR TITLE
Add shared E2E tests for UPF

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,6 +210,17 @@ jobs:
       test_flags: "-race -failfast -v -count=1"
       test_directory: "./test/integration/..."
       env_vars: "MODE=native DATAPATH=bess"
+  e2e-tests:
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+      id-token: write
+      attestations: write
+    uses: omec-project/.github/.github/workflows/e2e-test.yml@f977114a69e50ecb3ac7c334c630136c218f814e # test shared E2E workflow PR #204
+    with:
+      branch_name: ${{ github.ref }}
   license-check:
     permissions:
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -218,7 +218,7 @@ jobs:
       checks: write
       id-token: write
       attestations: write
-    uses: omec-project/.github/.github/workflows/e2e-test.yml@f977114a69e50ecb3ac7c334c630136c218f814e # test shared E2E workflow PR #204
+    uses: omec-project/.github/.github/workflows/e2e-test.yml@5c00590a8af523b43b03c3f1c9246afb7fa033b8 # test shared E2E workflow PR #204
     with:
       branch_name: ${{ github.ref }}
   license-check:


### PR DESCRIPTION
## Summary

Enable the shared E2E workflow for UPF pull requests.

- Runs the reusable `omec-project/.github` E2E workflow only for pull requests.
- Pins it to the immutable merge commit for shared-workflow release `v0.0.31` (`c1ddc83eed14046b21fe05de3dfe30054fea746e`).
- The shared workflow recognizes UPF, builds the `bess` and `pfcp` Dockerfile targets, overrides both Helm image tags with the locally built testing images, and runs the deployed GNBSIM E2E test.
