### PR TITLE
refactor: simplify CLI parsing logic, secure subprocesses

### DIFF
--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -33,7 +33,7 @@ func TestUPFBasedUeIPAllocation(t *testing.T) {
 			ueAddress: "10.250.0.1",
 			appFilter: appFilter{
 				proto:        0x11,
-				appIP:        net.ParseIP("0.0.0.0"),
+				appIP:        net.ParseIP(anyIPv4Address),
 				appPrefixLen: 0,
 				appPort: portRange{
 					80, 80,
@@ -169,7 +169,7 @@ func TestSingleUEAttachAndDetach(t *testing.T) {
 			expected: ueSessionConfig{
 				appFilter: appFilter{
 					proto:        0x11,
-					appIP:        net.ParseIP("0.0.0.0"),
+					appIP:        net.ParseIP(anyIPv4Address),
 					appPrefixLen: 0,
 					appPort: portRange{
 						80, 80,
@@ -242,7 +242,7 @@ func TestSingleUEAttachAndDetach(t *testing.T) {
 			expected: ueSessionConfig{
 				appFilter: appFilter{
 					proto:        0x11,
-					appIP:        net.ParseIP("0.0.0.0"),
+					appIP:        net.ParseIP(anyIPv4Address),
 					appPrefixLen: 0,
 					appPort: portRange{
 						80, 80,
@@ -274,7 +274,7 @@ func TestSingleUEAttachAndDetach(t *testing.T) {
 			expected: ueSessionConfig{
 				appFilter: appFilter{
 					proto:        0x11,
-					appIP:        net.ParseIP("0.0.0.0"),
+					appIP:        net.ParseIP(anyIPv4Address),
 					appPrefixLen: 0,
 					appPort: portRange{
 						80, 80,
@@ -306,7 +306,7 @@ func TestSingleUEAttachAndDetach(t *testing.T) {
 			expected: ueSessionConfig{
 				appFilter: appFilter{
 					proto:        0x11,
-					appIP:        net.ParseIP("0.0.0.0"),
+					appIP:        net.ParseIP(anyIPv4Address),
 					appPrefixLen: 0,
 					appPort: portRange{
 						80, 80,
@@ -339,7 +339,7 @@ func TestSingleUEAttachAndDetach(t *testing.T) {
 			expected: ueSessionConfig{
 				appFilter: appFilter{
 					proto:        0x11,
-					appIP:        net.ParseIP("0.0.0.0"),
+					appIP:        net.ParseIP(anyIPv4Address),
 					appPrefixLen: 0,
 					appPort: portRange{
 						80, 80,
@@ -372,7 +372,7 @@ func TestSingleUEAttachAndDetach(t *testing.T) {
 			expected: ueSessionConfig{
 				appFilter: appFilter{
 					proto:        0x11,
-					appIP:        net.ParseIP("0.0.0.0"),
+					appIP:        net.ParseIP(anyIPv4Address),
 					appPrefixLen: 0,
 					appPort: portRange{
 						80, 80,
@@ -409,7 +409,7 @@ func TestUEBuffering(t *testing.T) {
 		expected: ueSessionConfig{
 			appFilter: appFilter{
 				proto:        0x11,
-				appIP:        net.ParseIP("0.0.0.0"),
+				appIP:        net.ParseIP(anyIPv4Address),
 				appPrefixLen: 0,
 				appPort: portRange{
 					80, 80,

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -34,6 +34,10 @@ const (
 	ActionDrop    uint8 = 0x1
 	ActionBuffer  uint8 = 0x4
 	ActionNotify  uint8 = 0x8
+
+	localhostAltIP = "127.0.0.8"
+	localhostIP    = "127.0.0.1"
+	anyIPv4Address = "0.0.0.0"
 )
 
 type UEState uint8
@@ -188,7 +192,7 @@ func waitForPFCPAssociationSetup(pfcpClient *pfcpsim.PFCPClient) error {
 }
 
 func waitForBESSFakeToStart() error {
-	return waitForPortOpen("tcp", "127.0.0.1", "10514")
+	return waitForPortOpen("tcp", localhostIP, "10514")
 }
 
 func setup(t *testing.T, configType uint32) {
@@ -208,12 +212,12 @@ func setup(t *testing.T, configType uint32) {
 	}
 
 	upfConf := GetConfig(configType)
-	upfConf.N4Addr = "127.0.0.8"
+	upfConf.N4Addr = localhostAltIP
 	pfcpAgent = pfcpiface.NewPFCPIface(upfConf)
 	go pfcpAgent.Run()
 
-	pfcpClient = pfcpsim.NewPFCPClient("127.0.0.1")
-	errConn := pfcpClient.ConnectN4("127.0.0.8")
+	pfcpClient = pfcpsim.NewPFCPClient(localhostIP)
+	errConn := pfcpClient.ConnectN4(localhostAltIP)
 	if errConn != nil {
 		t.Fatalf("failed to connect to UPF: %v", errConn)
 	}


### PR DESCRIPTION
**Description**
This PR refactors repeated string literals in test/integration/basic_test.go and test/integration/framework.go to improve code maintainability and resolve duplication warnings in the integration test suite.

**Key Changes**

Consolidated IP Address Literals (basic_test.go, framework.go): Defined constants for frequently duplicated IP values ("0.0.0.0", "127.0.0.1", and "127.0.0.8") used across the integration framework configurations.